### PR TITLE
feat: gardener Telegram alerting on failure

### DIFF
--- a/gardener/src/alert.ts
+++ b/gardener/src/alert.ts
@@ -1,0 +1,35 @@
+import type { Env } from './types';
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Send a failure alert to Telegram. Best-effort — returns silently if
+ * alert secrets are not configured or if the Telegram API call fails.
+ * Never throws.
+ */
+export async function sendAlert(env: Env, error: unknown): Promise<void> {
+  if (!env.TELEGRAM_BOT_TOKEN || !env.TELEGRAM_ALERT_CHAT_ID) return;
+
+  const detail = escapeHtml(String(error).slice(0, 1000));
+  const text = `<b>Gardener failed</b>\n<pre>${detail}</pre>`;
+
+  try {
+    await fetch(
+      `https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/sendMessage`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          chat_id: env.TELEGRAM_ALERT_CHAT_ID,
+          text,
+          parse_mode: 'HTML',
+        }),
+      },
+    );
+  } catch {
+    // Alert delivery failed — original error is already in console.error.
+    // Nothing useful to do here.
+  }
+}

--- a/gardener/src/index.ts
+++ b/gardener/src/index.ts
@@ -1,6 +1,7 @@
 import { createSupabaseClient, deleteGardenerSimilarityLinks, fetchNotesForSimilarity, findSimilarNotes, insertSimilarityLinks, logEnrichments } from './db';
 import { loadConfig } from './config';
 import { buildContext } from './similarity';
+import { sendAlert } from './alert';
 import type { Env, SimilarityLink } from './types';
 
 async function runSimilarityLinker(env: Env): Promise<void> {
@@ -87,6 +88,7 @@ export default {
         event: 'gardener_run_failed',
         error: String(err),
       }));
+      await sendAlert(env, err);
     }
   },
 };

--- a/gardener/src/types.ts
+++ b/gardener/src/types.ts
@@ -4,6 +4,9 @@ export interface Env {
   SUPABASE_URL: string;
   SUPABASE_SERVICE_ROLE_KEY: string;
   GARDENER_SIMILARITY_THRESHOLD: string;
+  // Optional — alerting degrades gracefully if not set
+  TELEGRAM_BOT_TOKEN?: string;
+  TELEGRAM_ALERT_CHAT_ID?: string;
 }
 
 // ── Domain types ─────────────────────────────────────────────────────────────

--- a/gardener/wrangler.toml
+++ b/gardener/wrangler.toml
@@ -18,3 +18,5 @@ crons = ["0 2 * * *"]
 # Secrets (set via: wrangler secret put <NAME> -c gardener/wrangler.toml):
 # SUPABASE_URL
 # SUPABASE_SERVICE_ROLE_KEY
+# TELEGRAM_BOT_TOKEN         (optional — enables failure alerts to Telegram)
+# TELEGRAM_ALERT_CHAT_ID     (optional — chat ID to receive failure alerts)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -65,7 +65,7 @@ echo ""
 
 # ── Step 3: Unit tests ────────────────────────────────────────────────────────
 echo "▶  3/6  Unit tests..."
-npx vitest run tests/parser.test.ts tests/gardener-similarity.test.ts tests/gardener-config.test.ts
+npx vitest run tests/parser.test.ts tests/gardener-similarity.test.ts tests/gardener-config.test.ts tests/gardener-alert.test.ts
 echo ""
 
 # ── Step 4: Deploy Telegram Worker ───────────────────────────────────────────

--- a/tests/gardener-alert.test.ts
+++ b/tests/gardener-alert.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendAlert } from '../gardener/src/alert';
+import type { Env } from '../gardener/src/types';
+
+const BASE_ENV: Env = {
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_SERVICE_ROLE_KEY: 'service-key',
+  GARDENER_SIMILARITY_THRESHOLD: '0.70',
+  TELEGRAM_BOT_TOKEN: 'test-bot-token',
+  TELEGRAM_ALERT_CHAT_ID: '12345',
+};
+
+function env(overrides: Partial<Env> = {}): Env {
+  return { ...BASE_ENV, ...overrides };
+}
+
+// ── sendAlert ────────────────────────────────────────────────────────────────
+
+describe('sendAlert', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends a POST to the Telegram API with the error message', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok'));
+
+    await sendAlert(env(), new Error('DB connection timeout'));
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, opts] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe('https://api.telegram.org/bottest-bot-token/sendMessage');
+    const body = JSON.parse((opts as RequestInit).body as string);
+    expect(body.chat_id).toBe('12345');
+    expect(body.parse_mode).toBe('HTML');
+    expect(body.text).toContain('Gardener failed');
+    expect(body.text).toContain('DB connection timeout');
+  });
+
+  it('does nothing when TELEGRAM_BOT_TOKEN is missing', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok'));
+
+    await sendAlert(env({ TELEGRAM_BOT_TOKEN: undefined }), 'some error');
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when TELEGRAM_ALERT_CHAT_ID is missing', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok'));
+
+    await sendAlert(env({ TELEGRAM_ALERT_CHAT_ID: undefined }), 'some error');
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when both alert secrets are missing', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok'));
+
+    await sendAlert(env({ TELEGRAM_BOT_TOKEN: undefined, TELEGRAM_ALERT_CHAT_ID: undefined }), 'err');
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('escapes HTML characters in the error message', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok'));
+
+    await sendAlert(env(), new Error('Expected <tag> & "value"'));
+
+    const body = JSON.parse((fetchSpy.mock.calls[0]![1] as RequestInit).body as string);
+    expect(body.text).toContain('&lt;tag&gt;');
+    expect(body.text).toContain('&amp;');
+    expect(body.text).not.toContain('<tag>');
+  });
+
+  it('truncates long error messages to 1000 characters', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok'));
+    const longError = 'x'.repeat(2000);
+
+    await sendAlert(env(), longError);
+
+    const body = JSON.parse((fetchSpy.mock.calls[0]![1] as RequestInit).body as string);
+    // The <pre> content should be at most 1000 chars of the error
+    const preMatch = body.text.match(/<pre>(.*?)<\/pre>/s);
+    expect(preMatch).toBeTruthy();
+    expect(preMatch![1].length).toBeLessThanOrEqual(1000);
+  });
+
+  it('never throws even when fetch fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'));
+
+    // Should not throw
+    await expect(sendAlert(env(), 'gardener broke')).resolves.toBeUndefined();
+  });
+
+  it('never throws even when fetch throws synchronously', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      throw new Error('sync explosion');
+    });
+
+    await expect(sendAlert(env(), 'gardener broke')).resolves.toBeUndefined();
+  });
+
+  it('handles non-Error objects as the error argument', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok'));
+
+    await sendAlert(env(), { code: 'ECONNREFUSED', message: 'refused' });
+
+    const body = JSON.parse((fetchSpy.mock.calls[0]![1] as RequestInit).body as string);
+    expect(body.text).toContain('Gardener failed');
+    // String({code: ...}) produces [object Object], but that's fine — it's a fallback
+    expect(body.text).toContain('<pre>');
+  });
+
+  it('handles string errors', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok'));
+
+    await sendAlert(env(), 'plain string error');
+
+    const body = JSON.parse((fetchSpy.mock.calls[0]![1] as RequestInit).body as string);
+    expect(body.text).toContain('plain string error');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds best-effort Telegram alerting when the gardener's nightly cron fails
- Reuses the existing capture bot — same bot token, same chat. No second bot, no email.
- Graceful degradation: if alert secrets aren't configured, gardener runs normally with no alerting
- Error messages are HTML-escaped and truncated to 1000 chars to avoid leaking sensitive DB details

Closes #35

## Changes

- `gardener/src/alert.ts` — new file: `sendAlert(env, error)` + `escapeHtml()`
- `gardener/src/types.ts` — optional `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ALERT_CHAT_ID` in Env
- `gardener/src/index.ts` — calls `sendAlert` in the catch block (after `console.error`)
- `gardener/wrangler.toml` — documents the two new optional secrets
- `tests/gardener-alert.test.ts` — 10 unit tests
- `scripts/deploy.sh` — includes alert tests in step 3

## Test plan

- [x] 10 new unit tests: happy path, missing secrets (3 variants), HTML escaping, truncation, fetch rejection, fetch sync throw, non-Error objects, string errors
- [x] Existing 25 gardener tests still pass
- [x] Typecheck clean (`tsc --noEmit -p gardener/tsconfig.json`)
- [ ] After merge: `wrangler secret put TELEGRAM_BOT_TOKEN -c gardener/wrangler.toml` and `wrangler secret put TELEGRAM_ALERT_CHAT_ID -c gardener/wrangler.toml`, then deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)