### PR TITLE
feat: gardener /trigger endpoint for smoke testing and manual runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,12 +67,13 @@ gardener/
   wrangler.toml      # Gardener Worker config (name: contemplace-gardener, cron: 0 2 * * *)
   tsconfig.json
   src/
-    index.ts         # scheduled() export only — no fetch handler
+    index.ts         # scheduled() + fetch() exports — cron handler + POST /trigger endpoint
     config.ts        # Config loading (SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, GARDENER_SIMILARITY_THRESHOLD)
     db.ts            # deleteGardenerSimilarityLinks, fetchNotesForSimilarity, findSimilarNotes,
                      # insertSimilarityLinks, logEnrichments
     similarity.ts    # buildContext() — auto-generates link context from shared tags + entities
     alert.ts         # sendAlert() — best-effort Telegram failure notification
+    auth.ts          # validateTriggerAuth() — Bearer token auth for /trigger endpoint
     types.ts         # Gardener-specific TypeScript interfaces
 scripts/
   deploy.sh          # Automated 6-step deploy pipeline (schema → typecheck → unit tests → Telegram Worker → Gardener Worker → smoke tests)
@@ -96,6 +97,7 @@ tests/
   gardener-similarity.test.ts # Unit tests for buildContext() and UUID ordering deduplication (13 tests)
   gardener-config.test.ts     # Unit tests for gardener/src/config.ts loadConfig (12 tests)
   gardener-alert.test.ts      # Unit tests for sendAlert() — Telegram alerting (10 tests)
+  gardener-trigger.test.ts    # Unit tests for /trigger endpoint auth + routing (13 tests)
 docs/                # Detailed documentation (architecture, capture agent, schema, decisions, roadmap)
 wrangler.toml        # Telegram Worker Cloudflare config
 package.json
@@ -133,6 +135,7 @@ MCP_SEARCH_THRESHOLD        # default: 0.35 — used only by search_notes. Lower
 # SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are shared with the Telegram Worker above.
 TELEGRAM_BOT_TOKEN            # optional — same as capture Worker; enables failure alerts to Telegram
 TELEGRAM_ALERT_CHAT_ID        # optional — chat ID to receive failure alerts (same as ALLOWED_CHAT_IDS)
+GARDENER_API_KEY              # optional — enables POST /trigger endpoint (generate with: openssl rand -hex 32)
 
 # Gardener Worker configurable — defaults in gardener/wrangler.toml [vars]
 GARDENER_SIMILARITY_THRESHOLD  # default: 0.70 — augmented-vs-augmented cosine similarity.
@@ -195,12 +198,13 @@ wrangler secret put SUPABASE_URL -c gardener/wrangler.toml
 wrangler secret put SUPABASE_SERVICE_ROLE_KEY -c gardener/wrangler.toml
 wrangler secret put TELEGRAM_BOT_TOKEN -c gardener/wrangler.toml        # optional — failure alerts
 wrangler secret put TELEGRAM_ALERT_CHAT_ID -c gardener/wrangler.toml    # optional — failure alerts
+wrangler secret put GARDENER_API_KEY -c gardener/wrangler.toml          # optional — enables /trigger endpoint
 
 # Typecheck the Gardener Worker
 npx tsc --noEmit -p gardener/tsconfig.json
 
 # Run Gardener unit tests (local, no network)
-npx vitest run tests/gardener-similarity.test.ts tests/gardener-config.test.ts tests/gardener-alert.test.ts
+npx vitest run tests/gardener-similarity.test.ts tests/gardener-config.test.ts tests/gardener-alert.test.ts tests/gardener-trigger.test.ts
 
 # Trigger a gardener run locally against the live DB (symlink gardener/.dev.vars → .dev.vars first)
 # ln -s ../.dev.vars gardener/.dev.vars

--- a/gardener/src/auth.ts
+++ b/gardener/src/auth.ts
@@ -1,0 +1,17 @@
+import type { Env } from './types';
+
+export function validateTriggerAuth(request: Request, env: Env): Response | null {
+  if (!env.GARDENER_API_KEY) {
+    return new Response('Trigger endpoint not configured', { status: 403 });
+  }
+  const authHeader = request.headers.get('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  const token = authHeader.slice(7);
+  if (token !== env.GARDENER_API_KEY) {
+    console.warn(JSON.stringify({ event: 'auth_failed', reason: 'invalid_token' }));
+    return new Response('Forbidden', { status: 403 });
+  }
+  return null;
+}

--- a/gardener/src/index.ts
+++ b/gardener/src/index.ts
@@ -2,9 +2,20 @@ import { createSupabaseClient, deleteGardenerSimilarityLinks, fetchNotesForSimil
 import { loadConfig } from './config';
 import { buildContext } from './similarity';
 import { sendAlert } from './alert';
+import { validateTriggerAuth } from './auth';
 import type { Env, SimilarityLink } from './types';
 
-async function runSimilarityLinker(env: Env): Promise<void> {
+export interface GardenerRunResult {
+  event: 'gardener_run_complete';
+  notes_processed: number;
+  links_deleted: number;
+  links_created: number;
+  enriched_notes: number;
+  duration_ms: number;
+  errors: string[];
+}
+
+export async function runSimilarityLinker(env: Env): Promise<GardenerRunResult> {
   const startTime = Date.now();
   const errors: string[] = [];
 
@@ -63,8 +74,7 @@ async function runSimilarityLinker(env: Env): Promise<void> {
   // 4. Log enrichment entries for notes that received new outbound links.
   await logEnrichments(db, [...enrichedNoteIds]);
 
-  // 5. Structured run summary — queryable via: wrangler tail --name contemplace-gardener
-  console.log(JSON.stringify({
+  const result: GardenerRunResult = {
     event: 'gardener_run_complete',
     notes_processed: notes.length,
     links_deleted: linksDeleted,
@@ -72,11 +82,16 @@ async function runSimilarityLinker(env: Env): Promise<void> {
     enriched_notes: enrichedNoteIds.size,
     duration_ms: Date.now() - startTime,
     errors,
-  }));
+  };
+
+  // 5. Structured run summary — queryable via: wrangler tail --name contemplace-gardener
+  console.log(JSON.stringify(result));
 
   if (errors.length > 0) {
     throw new Error(`Gardener run completed with ${errors.length} error(s) — see logs above`);
   }
+
+  return result;
 }
 
 export default {
@@ -89,6 +104,42 @@ export default {
         error: String(err),
       }));
       await sendAlert(env, err);
+    }
+  },
+
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname !== '/trigger') {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    if (request.method !== 'POST') {
+      return new Response('Method Not Allowed', { status: 405 });
+    }
+
+    const authError = validateTriggerAuth(request, env);
+    if (authError) return authError;
+
+    try {
+      const result = await runSimilarityLinker(env);
+      return new Response(JSON.stringify(result), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    } catch (err) {
+      console.error(JSON.stringify({
+        event: 'gardener_run_failed',
+        error: String(err),
+      }));
+      await sendAlert(env, err);
+      return new Response(JSON.stringify({
+        event: 'gardener_run_failed',
+        error: String(err),
+      }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
     }
   },
 };

--- a/gardener/src/types.ts
+++ b/gardener/src/types.ts
@@ -7,6 +7,8 @@ export interface Env {
   // Optional — alerting degrades gracefully if not set
   TELEGRAM_BOT_TOKEN?: string;
   TELEGRAM_ALERT_CHAT_ID?: string;
+  // Optional — enables POST /trigger endpoint for manual runs and smoke tests
+  GARDENER_API_KEY?: string;
 }
 
 // ── Domain types ─────────────────────────────────────────────────────────────

--- a/gardener/wrangler.toml
+++ b/gardener/wrangler.toml
@@ -20,3 +20,4 @@ crons = ["0 2 * * *"]
 # SUPABASE_SERVICE_ROLE_KEY
 # TELEGRAM_BOT_TOKEN         (optional — enables failure alerts to Telegram)
 # TELEGRAM_ALERT_CHAT_ID     (optional — chat ID to receive failure alerts)
+# GARDENER_API_KEY           (optional — enables POST /trigger endpoint for manual runs)

--- a/tests/gardener-trigger.test.ts
+++ b/tests/gardener-trigger.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { validateTriggerAuth } from '../gardener/src/auth';
+import type { Env } from '../gardener/src/types';
+
+const BASE_ENV: Env = {
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_SERVICE_ROLE_KEY: 'service-key',
+  GARDENER_SIMILARITY_THRESHOLD: '0.70',
+  GARDENER_API_KEY: 'test-gardener-key',
+};
+
+function env(overrides: Partial<Env> = {}): Env {
+  return { ...BASE_ENV, ...overrides };
+}
+
+function makeRequest(method: string, path: string, headers: Record<string, string> = {}): Request {
+  return new Request(`https://contemplace-gardener.workers.dev${path}`, { method, headers });
+}
+
+// ── validateTriggerAuth ──────────────────────────────────────────────────────
+
+describe('validateTriggerAuth', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null (success) for a valid Bearer token', () => {
+    const req = makeRequest('POST', '/trigger', { Authorization: 'Bearer test-gardener-key' });
+    const result = validateTriggerAuth(req, env());
+    expect(result).toBeNull();
+  });
+
+  it('returns 401 when Authorization header is missing', () => {
+    const req = makeRequest('POST', '/trigger');
+    const result = validateTriggerAuth(req, env());
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(401);
+  });
+
+  it('returns 401 when Authorization header does not start with Bearer', () => {
+    const req = makeRequest('POST', '/trigger', { Authorization: 'Basic abc123' });
+    const result = validateTriggerAuth(req, env());
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(401);
+  });
+
+  it('returns 403 when the token is invalid', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const req = makeRequest('POST', '/trigger', { Authorization: 'Bearer wrong-key' });
+    const result = validateTriggerAuth(req, env());
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+    expect(warnSpy).toHaveBeenCalledOnce();
+  });
+
+  it('returns 403 with message when GARDENER_API_KEY is not set', () => {
+    const req = makeRequest('POST', '/trigger', { Authorization: 'Bearer some-key' });
+    const result = validateTriggerAuth(req, env({ GARDENER_API_KEY: undefined }));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  it('returns 403 with "not configured" body when GARDENER_API_KEY is not set', async () => {
+    const req = makeRequest('POST', '/trigger', { Authorization: 'Bearer some-key' });
+    const result = validateTriggerAuth(req, env({ GARDENER_API_KEY: undefined }));
+    const body = await result!.text();
+    expect(body).toBe('Trigger endpoint not configured');
+  });
+});
+
+// ── fetch handler (routing + integration) ────────────────────────────────────
+
+describe('fetch handler', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // We import the default export which has fetch and scheduled
+  async function callFetch(method: string, path: string, envOverrides: Partial<Env> = {}, headers: Record<string, string> = {}): Promise<Response> {
+    // Dynamic import to allow vi.mock to take effect
+    const mod = await import('../gardener/src/index');
+    const req = makeRequest(method, path, headers);
+    return mod.default.fetch(req, env(envOverrides));
+  }
+
+  it('returns 404 for unknown paths', async () => {
+    const resp = await callFetch('POST', '/unknown', {}, { Authorization: 'Bearer test-gardener-key' });
+    expect(resp.status).toBe(404);
+  });
+
+  it('returns 405 for GET /trigger', async () => {
+    const resp = await callFetch('GET', '/trigger', {}, { Authorization: 'Bearer test-gardener-key' });
+    expect(resp.status).toBe(405);
+  });
+
+  it('returns 405 for PUT /trigger', async () => {
+    const resp = await callFetch('PUT', '/trigger', {}, { Authorization: 'Bearer test-gardener-key' });
+    expect(resp.status).toBe(405);
+  });
+
+  it('returns 401 without auth header', async () => {
+    const resp = await callFetch('POST', '/trigger');
+    expect(resp.status).toBe(401);
+  });
+
+  it('returns 403 with wrong token', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const resp = await callFetch('POST', '/trigger', {}, { Authorization: 'Bearer wrong' });
+    expect(resp.status).toBe(403);
+  });
+
+  it('returns 403 when GARDENER_API_KEY is not configured', async () => {
+    const resp = await callFetch('POST', '/trigger', { GARDENER_API_KEY: undefined }, { Authorization: 'Bearer anything' });
+    expect(resp.status).toBe(403);
+    const body = await resp.text();
+    expect(body).toBe('Trigger endpoint not configured');
+  });
+});
+
+// ── runSimilarityLinker result shape ─────────────────────────────────────────
+
+describe('runSimilarityLinker return type', () => {
+  it('exports GardenerRunResult interface fields', async () => {
+    // Verify the exported type exists by importing it
+    const mod = await import('../gardener/src/index');
+    expect(mod.runSimilarityLinker).toBeDefined();
+    expect(typeof mod.runSimilarityLinker).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `POST /trigger` endpoint to the gardener Worker alongside the existing `scheduled()` cron handler
- Bearer token auth via `GARDENER_API_KEY` secret (same pattern as MCP Worker's `MCP_API_KEY`)
- Endpoint is optional — if `GARDENER_API_KEY` is not set, returns 403 "not configured"; cron continues to work
- `runSimilarityLinker()` refactored to return a `GardenerRunResult` object (exported) instead of void — same structured JSON that was previously only logged to console
- 13 new unit tests covering auth (6 tests) + routing/integration (6 tests) + export verification (1 test)
- All 48 gardener tests pass, both typechecks clean

## Files changed

| File | Change |
|---|---|
| `gardener/src/auth.ts` | **New.** `validateTriggerAuth()` — Bearer token validation |
| `gardener/src/index.ts` | Add `fetch()` export, refactor `runSimilarityLinker` to return result |
| `gardener/src/types.ts` | Add optional `GARDENER_API_KEY` to `Env` |
| `gardener/wrangler.toml` | Document `GARDENER_API_KEY` secret |
| `tests/gardener-trigger.test.ts` | **New.** 13 unit tests |
| `CLAUDE.md` | Updated project layout, env vars, key commands |

## Post-merge steps

1. Deploy: `wrangler deploy -c gardener/wrangler.toml`
2. Set secret: `wrangler secret put GARDENER_API_KEY -c gardener/wrangler.toml`
3. Verify: `curl -X POST https://contemplace-gardener.adamfreisinger.workers.dev/trigger -H "Authorization: Bearer $GARDENER_API_KEY"`

## Test plan

- [x] `npx tsc --noEmit -p gardener/tsconfig.json` — typecheck clean
- [x] `npx vitest run tests/gardener-trigger.test.ts` — 13 tests pass
- [x] All 48 gardener unit tests pass (existing 35 + new 13)
- [ ] Deploy and verify with curl (post-merge)
- [ ] Smoke test (#33) — separate PR

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)