### PR TITLE
fix: batch gardener subrequests — refined_tags + similarity linker

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -292,3 +292,47 @@ The four independent thresholds:
 **Decision (2026-03-10):** Use the `workers-oauth-provider` library's opaque token format rather than JWTs. Reversing the original plan's assumption of "signed JWTs."
 
 **Why:** The library stores token hashes in KV and validates via hash lookup. This means token validation requires a KV read per request (~sub-ms cached). The tradeoff vs JWTs: revocation is immediate (delete from KV), no signing key management, and the library handles everything. For a single-user system, the KV read latency is negligible. JWTs would require either forking the library or building a parallel validation path — unnecessary complexity.
+
+## Maturity/importance scoring: deferred until real graph patterns emerge
+
+**Decision (2026-03-10):** Defer maturity and importance scoring from Phase 2b. Build chunk generation instead.
+
+**Why:** The user's mental model of maturity is emergent and graph-driven, not per-note threshold scoring. Notes accumulate links naturally. When a cluster reaches critical mass, a "map of content" (MOC) emerges as a gravitational center — a concept from the Zettelkasten/PKM tradition. Freshness means a note was recently linked to new notes (currently on the user's mind). Density means many relations. MOCs eventually split when they grow too large and get linked together.
+
+This model is closer to community detection in graph theory than to a formula like `if links > 3 and age > 7 days then budding`. Designing the algorithm requires observing real graph evolution — what link densities emerge naturally, what cluster sizes trigger the "gravitational" effect, when splitting feels right. These patterns don't exist yet with ~30 notes.
+
+The "revisit count" signal from the original issue (#2) is also deferred. No tracking mechanism exists, and adding counters to read paths would produce noisy data (agent iteration inflates counts meaninglessly). If engagement tracking is needed later, it should be a separate analytics layer, not a column on `notes`.
+
+## Chunk generation: paragraph-boundary splitting for brain dumps
+
+**Decision (2026-03-10):** Build chunk generation in the gardener to support brain dump inputs. Paragraph-boundary splitting, ~500-800 character chunks, 1500-character minimum body length to qualify.
+
+**Why:** The user is starting to experiment with brain dumps (multi-paragraph inputs via Telegram), which are chunkier than the current 1-5 sentence notes. Schema (`note_chunks`, `match_chunks` RPC) already exists. Building the infrastructure now means brain dumps work end-to-end immediately.
+
+**Design choices:**
+- **Splitting strategy:** Paragraph boundaries (double newlines). If a single paragraph exceeds the chunk size cap, fall back to sentence-boundary splitting within that paragraph. No overlap — ContemPlace notes are personal notes, not long technical documents. Paragraphs are natural semantic units.
+- **Chunk content:** Store raw chunk text in `note_chunks.content`. At embed time, prepend `{note.title}: {chunk_text}` for context anchoring. Do not embed type/intent/tags metadata into chunks — those are note-level, not chunk-level.
+- **Idempotency:** Skip-if-body-unchanged. Check `enrichment_log` timestamp for `enrichment_type = 'chunking'` vs `notes.updated_at`. If chunks exist and note hasn't changed, skip. If note was updated, delete existing chunks and re-chunk. Avoids re-embedding the entire corpus nightly.
+- **Embedding:** Use `batchEmbedTexts` for all chunks in one API call (1 subrequest). The OpenAI batch limit is 2048 inputs — well above expected volume.
+
+**Prerequisite:** Batch `updateRefinedTags` in tag normalization to free subrequest budget. Currently makes one Supabase call per note (~30 calls), which combined with the similarity linker's per-note RPCs already strains the 50-subrequest free tier limit.
+
+## Supabase RPC functions: OPERATOR(extensions.<=>) required for pgvector
+
+**Decision (2026-03-10):** RPC functions that use pgvector's `<=>` operator must use the explicit `OPERATOR(extensions.<=>)` syntax, not the bare `<=>` operator, even when `extensions` is in the function's `SET search_path`.
+
+**Why:** PostgREST's execution context cannot resolve operators via `search_path` alone. The bare `<=>` operator fails with `operator does not exist: extensions.vector <=> extensions.vector` — PostgreSQL identifies the types correctly but cannot find the operator. The existing `match_notes` function works with bare `<=>` because it was created in the initial schema migration (different execution context). Functions created via later migrations through the connection pooler require explicit operator qualification.
+
+Tables must also use explicit `public.notes` references rather than bare `notes` for the same reason.
+
+This applies to any new RPC function that uses pgvector operators (`<=>`, `<->`, `<#>`). Use `OPERATOR(extensions.<=>)` and `public.table_name` to be safe.
+
+## Similarity linker: find_similar_pairs replaces per-note RPC calls
+
+**Decision (2026-03-10):** Replace the per-note `findSimilarNotes` RPC calls (N subrequests) with a single `find_similar_pairs` SQL self-join function (1 subrequest).
+
+**Why:** The per-note approach made N Supabase RPC calls, one per note, consuming N subrequests. At 30 notes this was ~30 subrequests just for the similarity linker. Combined with tag normalization, the total exceeded the 50-subrequest free tier limit. The self-join computes all pairs above threshold in a single query using `a.id < b.id` ordering (each pair appears once). At 300 notes this is ~45,000 cosine distance comparisons — well under a second in Postgres. Combined with batching `insertSimilarityLinks` (all links in one INSERT instead of per-note batches), the entire similarity linker now uses ~5 fixed subrequests regardless of corpus size.
+
+**Scale ceiling:** The brute-force self-join is O(N²). At 1000+ notes, consider an ANN-based approach or pagination.
+
+**Imports context:** Future Obsidian/ChatGPT imports would be agent-driven via MCP `capture_note` in small batches, not bulk automated. No heading-aware splitting needed yet — brain dumps are prose, not structured markdown. Can add heading-awareness later if import content structure demands it.

--- a/gardener/src/db.ts
+++ b/gardener/src/db.ts
@@ -1,6 +1,6 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import type { Config } from './config';
-import type { Concept, Entity, NoteForSimilarity, NoteForTagNorm, SimilarNote, SimilarityLink } from './types';
+import type { Concept, Entity, NoteForSimilarity, NoteForTagNorm, SimilarityLink } from './types';
 
 export function createSupabaseClient(config: Config): SupabaseClient {
   return createClient(config.supabaseUrl, config.supabaseServiceRoleKey);
@@ -55,42 +55,27 @@ export async function fetchNotesForSimilarity(db: SupabaseClient): Promise<NoteF
   }));
 }
 
-// Find notes similar to the given embedding above the threshold via match_notes RPC.
-// match_notes does not filter the query note itself — self-similarity (score 1.0)
-// must be filtered by the caller.
-// match_count=50 is generous; at threshold 0.70 a personal corpus is very unlikely
-// to have more than 50 similar neighbors per note.
-export async function findSimilarNotes(
+// Find all note pairs above a similarity threshold in a single round-trip.
+// Uses the find_similar_pairs RPC (self-join with a.id < b.id ordering).
+// Replaces per-note findSimilarNotes calls — 1 subrequest instead of N.
+export async function findSimilarPairs(
   db: SupabaseClient,
-  embedding: number[],
   threshold: number,
-): Promise<SimilarNote[]> {
-  const { data, error } = await db.rpc('match_notes', {
-    query_embedding: embedding,
-    match_threshold: threshold,
-    match_count: 50,
-    filter_type: null,
-    filter_source: null,
-    filter_tags: null,
-    filter_intent: null,
-    search_text: null,
+): Promise<Array<{ note_a: string; note_b: string; similarity: number }>> {
+  const { data, error } = await db.rpc('find_similar_pairs', {
+    similarity_threshold: threshold,
+    max_pairs: 10000,
   });
 
   if (error) {
-    throw new Error(`match_notes RPC failed: ${error.message}`);
+    throw new Error(`find_similar_pairs RPC failed: ${error.message}`);
   }
 
   return ((data as Array<{
-    id: string;
-    tags: string[] | null;
-    entities: unknown;
+    note_a: string;
+    note_b: string;
     similarity: number;
-  }>) ?? []).map(row => ({
-    id: row.id,
-    tags: row.tags ?? [],
-    entities: row.entities,
-    similarity: row.similarity,
-  }));
+  }>) ?? []);
 }
 
 // Bulk insert similarity links.
@@ -150,22 +135,6 @@ export async function fetchConcepts(db: SupabaseClient): Promise<Concept[]> {
         ? (JSON.parse(row.embedding) as number[])
         : row.embedding,
   }));
-}
-
-// Update a concept's embedding.
-export async function updateConceptEmbedding(
-  db: SupabaseClient,
-  conceptId: string,
-  embedding: number[],
-): Promise<void> {
-  const { error } = await db
-    .from('concepts')
-    .update({ embedding })
-    .eq('id', conceptId);
-
-  if (error) {
-    throw new Error(`Failed to update concept embedding ${conceptId}: ${error.message}`);
-  }
 }
 
 // Batch-update concept embeddings via upsert (single round-trip).
@@ -239,19 +208,23 @@ export async function insertNoteConcepts(
   }
 }
 
-// Update refined_tags for a single note.
-export async function updateRefinedTags(
+// Batch-update refined_tags for multiple notes in a single round-trip.
+// Uses the batch_update_refined_tags RPC function (single UPDATE ... FROM join).
+export async function batchUpdateRefinedTags(
   db: SupabaseClient,
-  noteId: string,
-  refinedTags: string[],
+  updates: Array<{ id: string; refined_tags: string[] }>,
 ): Promise<void> {
-  const { error } = await db
-    .from('notes')
-    .update({ refined_tags: refinedTags })
-    .eq('id', noteId);
+  if (updates.length === 0) return;
+
+  const { error } = await db.rpc('batch_update_refined_tags', {
+    updates: updates.map(u => ({
+      id: u.id,
+      refined_tags: u.refined_tags,
+    })),
+  });
 
   if (error) {
-    throw new Error(`Failed to update refined_tags for ${noteId}: ${error.message}`);
+    throw new Error(`Failed to batch update refined_tags: ${error.message}`);
   }
 }
 

--- a/gardener/src/index.ts
+++ b/gardener/src/index.ts
@@ -1,6 +1,6 @@
-import { createSupabaseClient, deleteGardenerSimilarityLinks, fetchNotesForSimilarity, findSimilarNotes, insertSimilarityLinks, logEnrichments,
+import { createSupabaseClient, deleteGardenerSimilarityLinks, fetchNotesForSimilarity, findSimilarPairs, insertSimilarityLinks, logEnrichments,
          fetchConcepts, batchUpdateConceptEmbeddings, fetchNotesForTagNorm, deleteGardenerNoteConcepts,
-         insertNoteConcepts, updateRefinedTags, deleteUnmatchedTagLogs, logUnmatchedTags, logTagNormEnrichments } from './db';
+         insertNoteConcepts, batchUpdateRefinedTags, deleteUnmatchedTagLogs, logUnmatchedTags, logTagNormEnrichments } from './db';
 import { loadConfig } from './config';
 import { buildContext } from './similarity';
 import { buildConceptEmbeddingInput, lexicalMatch, resolveNoteTags } from './normalize';
@@ -129,6 +129,7 @@ export async function runTagNormalization(env: Env): Promise<TagNormResult> {
   let totalUnmatched = 0;
   const allNoteConcepts: Array<{ note_id: string; concept_id: string }> = [];
   const allUnmatchedEntries: Array<{ note_id: string; tag: string }> = [];
+  const allRefinedTags: Array<{ id: string; refined_tags: string[] }> = [];
   const processedNoteIds: string[] = [];
 
   for (const note of notes) {
@@ -137,9 +138,8 @@ export async function runTagNormalization(env: Env): Promise<TagNormResult> {
         note, concepts, conceptsWithEmbeddings, tagEmbeddings, config.tagMatchThreshold,
       );
 
-      // Collect refined_tags update
-      const refinedTags = matched.map(m => m.prefLabel);
-      await updateRefinedTags(db, note.id, refinedTags);
+      // Collect refined_tags for batch update
+      allRefinedTags.push({ id: note.id, refined_tags: matched.map(m => m.prefLabel) });
 
       // Collect note_concepts rows
       for (const m of matched) {
@@ -160,6 +160,14 @@ export async function runTagNormalization(env: Env): Promise<TagNormResult> {
   }
 
   // 7. Batch writes
+  if (allRefinedTags.length > 0) {
+    try {
+      await batchUpdateRefinedTags(db, allRefinedTags);
+    } catch (err) {
+      errors.push(`refined_tags batch update: ${String(err)}`);
+    }
+  }
+
   if (allNoteConcepts.length > 0) {
     try {
       await insertNoteConcepts(db, allNoteConcepts);
@@ -197,37 +205,44 @@ export async function runSimilarityLinker(env: Env): Promise<{
   const config = loadConfig(env);
   const db = createSupabaseClient(config);
 
+  // 1. Clean slate
   const linksDeleted = await deleteGardenerSimilarityLinks(db);
-  const notes = await fetchNotesForSimilarity(db);
 
-  let linksCreated = 0;
+  // 2. Fetch notes (for tags/entities needed by buildContext) and similar pairs in parallel
+  const [notes, pairs] = await Promise.all([
+    fetchNotesForSimilarity(db),
+    findSimilarPairs(db, config.similarityThreshold),
+  ]);
+
+  // 3. Index notes by ID for fast lookup during context building
+  const noteMap = new Map(notes.map(n => [n.id, n]));
+
+  // 4. Build all links from pairs
+  const allLinks: SimilarityLink[] = [];
   const enrichedNoteIds = new Set<string>();
 
-  for (const noteA of notes) {
+  for (const pair of pairs) {
+    const noteA = noteMap.get(pair.note_a);
+    const noteB = noteMap.get(pair.note_b);
+    if (!noteA || !noteB) continue;
+
+    const context = buildContext(noteA, noteB, pair.similarity);
+    allLinks.push({
+      fromId: pair.note_a,
+      toId: pair.note_b,
+      confidence: pair.similarity,
+      context,
+    });
+    enrichedNoteIds.add(pair.note_a);
+    enrichedNoteIds.add(pair.note_b);
+  }
+
+  // 5. Batch insert all links in one call
+  if (allLinks.length > 0) {
     try {
-      const similar = await findSimilarNotes(db, noteA.embedding, config.similarityThreshold);
-      const linksToInsert: SimilarityLink[] = [];
-
-      for (const noteB of similar) {
-        if (noteA.id === noteB.id) continue;
-        if (noteA.id >= noteB.id) continue;
-
-        const context = buildContext(noteA, noteB, noteB.similarity);
-        linksToInsert.push({
-          fromId: noteA.id,
-          toId: noteB.id,
-          confidence: noteB.similarity,
-          context,
-        });
-      }
-
-      if (linksToInsert.length > 0) {
-        await insertSimilarityLinks(db, linksToInsert);
-        linksCreated += linksToInsert.length;
-        enrichedNoteIds.add(noteA.id);
-      }
+      await insertSimilarityLinks(db, allLinks);
     } catch (err) {
-      errors.push(`note ${noteA.id}: ${String(err)}`);
+      errors.push(`similarity links insert: ${String(err)}`);
     }
   }
 
@@ -236,7 +251,7 @@ export async function runSimilarityLinker(env: Env): Promise<{
   return {
     notes_processed: notes.length,
     links_deleted: linksDeleted,
-    links_created: linksCreated,
+    links_created: allLinks.length,
     enriched_notes: enrichedNoteIds.size,
     errors,
   };

--- a/gardener/src/types.ts
+++ b/gardener/src/types.ts
@@ -31,14 +31,6 @@ export interface NoteForSimilarity {
   embedding: number[];
 }
 
-// A note returned by match_notes RPC — includes similarity score.
-export interface SimilarNote {
-  id: string;
-  tags: string[];
-  entities: unknown; // jsonb from DB — cast via toEntityArray in similarity.ts
-  similarity: number;
-}
-
 // A link to be inserted into the links table.
 export interface SimilarityLink {
   fromId: string;

--- a/supabase/migrations/20260310000001_batch_update_refined_tags.sql
+++ b/supabase/migrations/20260310000001_batch_update_refined_tags.sql
@@ -1,0 +1,19 @@
+-- Batch-update refined_tags for multiple notes in a single round-trip.
+-- Replaces per-note UPDATE calls in the gardener tag normalization step,
+-- reducing Supabase subrequest count from N (one per note) to 1.
+--
+-- Input: JSONB array of objects: [{"id": "<uuid>", "refined_tags": ["tag1", "tag2"]}, ...]
+-- Uses a single UPDATE ... FROM join — one statement, not a loop.
+
+CREATE OR REPLACE FUNCTION batch_update_refined_tags(updates jsonb)
+RETURNS void
+LANGUAGE plpgsql
+SET search_path = 'public'
+AS $$
+BEGIN
+  UPDATE notes n
+  SET refined_tags = ARRAY(SELECT jsonb_array_elements_text(u.value->'refined_tags'))
+  FROM jsonb_array_elements(updates) AS u(value)
+  WHERE n.id = (u.value->>'id')::uuid;
+END;
+$$;

--- a/supabase/migrations/20260310000002_find_similar_pairs.sql
+++ b/supabase/migrations/20260310000002_find_similar_pairs.sql
@@ -1,0 +1,43 @@
+-- Find all note pairs with cosine similarity above a threshold.
+-- Replaces per-note match_notes RPC calls in the gardener similarity linker,
+-- reducing N subrequests to 1.
+--
+-- Uses a self-join with lexicographic UUID ordering (a.id < b.id) so each pair
+-- appears exactly once. This is a brute-force O(N²) comparison — appropriate for
+-- hundreds of notes. At 1000+ notes, consider an ANN-based approach.
+--
+-- NOTE: The <=> operator must use OPERATOR(extensions.<=>) syntax because
+-- PostgREST's execution context cannot resolve operators via search_path alone,
+-- even when the extensions schema is included. Explicit schema references
+-- for tables (public.notes) are also required for the same reason.
+
+create or replace function public.find_similar_pairs(
+  similarity_threshold float default 0.70,
+  max_pairs int default 10000
+)
+returns table (
+  note_a uuid,
+  note_b uuid,
+  similarity float
+)
+language plpgsql stable
+set search_path = 'public, extensions'
+as $$
+begin
+  return query
+  select
+    a.id as note_a,
+    b.id as note_b,
+    (1 - (a.embedding operator(extensions.<=>) b.embedding))::float as similarity
+  from public.notes a
+  join public.notes b on a.id < b.id
+  where
+    a.embedding is not null
+    and b.embedding is not null
+    and a.archived_at is null
+    and b.archived_at is null
+    and 1 - (a.embedding operator(extensions.<=>) b.embedding) > similarity_threshold
+  order by similarity desc
+  limit max_pairs;
+end;
+$$;


### PR DESCRIPTION
## Summary

- **Tag normalization**: replace per-note `updateRefinedTags` (N Supabase calls) with a single `batch_update_refined_tags` RPC function (1 call). New PL/pgSQL function uses `UPDATE ... FROM jsonb_array_elements`.
- **Similarity linker**: replace per-note `findSimilarNotes` (N calls) + per-note `insertSimilarityLinks` (up to N calls) with `find_similar_pairs` RPC (1 self-join call) + single batch insert (1 call).
- Total subrequests per gardener run: **~16 fixed** regardless of corpus size. Previously ~12 + 2N (612 at 300 notes).
- Removes unused `updateConceptEmbedding` and `SimilarNote` type.

**Discovery:** PostgREST cannot resolve pgvector's `<=>` operator via `search_path` in functions created through the Supabase connection pooler. Must use explicit `OPERATOR(extensions.<=>)` syntax and `public.table_name` references. ADR recorded.

## Test plan

- [x] All 265 unit tests pass
- [x] Gardener Worker deployed
- [x] `batch_update_refined_tags` RPC verified via curl
- [x] `find_similar_pairs` RPC verified via curl (returns correct pairs with similarity scores)
- [x] All 6 gardener integration tests pass (capture → trigger → get_related → verify links)
- [x] Migrations applied cleanly (2 new: `batch_update_refined_tags`, `find_similar_pairs`)

refs #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)