### PR TITLE
fix: rename capture_note param from text to raw_input

### DIFF
--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -82,14 +82,14 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'capture_note',
-    description: 'Capture a thought as a permanent note. Pass the user\'s raw input — the server embeds, finds related notes, and automatically generates a structured note (title, body, type, intent, tags, entities, links). Do not pre-structure, summarize, or clean up the text. Voice dictation errors are expected and corrected server-side. Side effect: creates a persistent note.',
+    description: 'Capture a thought as a permanent note. Required parameter: raw_input (the user\'s verbatim words). The server embeds, finds related notes, and automatically generates a structured note (title, body, type, intent, tags, entities, links). Do not pre-structure, summarize, or clean up the input. Voice dictation errors are expected and corrected server-side. Side effect: creates a persistent note.',
     inputSchema: {
       type: 'object',
       properties: {
-        text: { type: 'string', description: 'The user\'s exact words — do not rephrase, summarize, clean up, or add wrapper context. Pass through verbatim as spoken or typed. The server handles all structuring and voice-dictation correction. Max 4000 characters.' },
+        raw_input: { type: 'string', description: 'The user\'s exact words — do not rephrase, summarize, clean up, or add wrapper context. Pass through verbatim as spoken or typed. The server handles all structuring and voice-dictation correction. Max 4000 characters.' },
         source: { type: 'string', description: 'Identifies where this note came from. Default "mcp" is fine. Use a specific label when known — e.g., "claude-code", "obsidian-import". Alphanumeric/hyphens/underscores, max 100 chars.' },
       },
-      required: ['text'],
+      required: ['raw_input'],
     },
   },
   {
@@ -364,9 +364,9 @@ export async function handleCaptureNote(
   openai: OpenAI,
   config: Config,
 ): Promise<object> {
-  const text = args['text'];
-  if (typeof text !== 'string' || text.length === 0) return toolError('text is required');
-  if (text.length > 4000) return toolError('text exceeds 4000 character limit');
+  const text = args['raw_input'];
+  if (typeof text !== 'string' || text.length === 0) return toolError('raw_input is required');
+  if (text.length > 4000) return toolError('raw_input exceeds 4000 character limit');
 
   let source = typeof args['source'] === 'string' ? args['source'] : 'mcp';
   if (source.length > 100 || !SOURCE_RE.test(source)) {

--- a/tests/mcp-index.test.ts
+++ b/tests/mcp-index.test.ts
@@ -17,7 +17,7 @@ vi.mock('../mcp/src/tools', () => ({
     { name: 'get_note', description: 'Get', inputSchema: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] } },
     { name: 'list_recent', description: 'List', inputSchema: { type: 'object', properties: {} } },
     { name: 'get_related', description: 'Related', inputSchema: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] } },
-    { name: 'capture_note', description: 'Capture', inputSchema: { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] } },
+    { name: 'capture_note', description: 'Capture', inputSchema: { type: 'object', properties: { raw_input: { type: 'string' } }, required: ['raw_input'] } },
     { name: 'list_unmatched_tags', description: 'List unmatched', inputSchema: { type: 'object', properties: {} } },
     { name: 'promote_concept', description: 'Promote', inputSchema: { type: 'object', properties: { pref_label: { type: 'string' }, scheme: { type: 'string' } }, required: ['pref_label', 'scheme'] } },
     { name: 'search_chunks', description: 'Search chunks', inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } },
@@ -264,7 +264,7 @@ describe('MCP HTTP handler', () => {
     });
 
     it('dispatches to handleCaptureNote for name="capture_note"', async () => {
-      await rpc('tools/call', { name: 'capture_note', arguments: { text: 'hello' } });
+      await rpc('tools/call', { name: 'capture_note', arguments: { raw_input: 'hello' } });
       expect(vi.mocked(handleCaptureNote)).toHaveBeenCalledOnce();
     });
 

--- a/tests/mcp-smoke.test.ts
+++ b/tests/mcp-smoke.test.ts
@@ -190,7 +190,7 @@ describe('MCP Worker — capture_note, get_note, get_related', () => {
 
   it('capture_note creates a note and returns expected fields', async () => {
     const res = await callTool('capture_note', {
-      text: '[MCP-SMOKE] The test of a first-rate intelligence is the ability to hold two opposed ideas in mind at the same time.',
+      raw_input: '[MCP-SMOKE] The test of a first-rate intelligence is the ability to hold two opposed ideas in mind at the same time.',
       source: 'mcp-smoke-test',
     });
     expect(res.status).toBe(200);
@@ -246,8 +246,8 @@ describe('MCP Worker — capture_note, get_note, get_related', () => {
 });
 
 describe('MCP Worker — input validation (live)', () => {
-  it('capture_note with empty text returns isError: true', async () => {
-    const res = await callTool('capture_note', { text: '' });
+  it('capture_note with empty raw_input returns isError: true', async () => {
+    const res = await callTool('capture_note', { raw_input: '' });
     const body = await res.json() as Record<string, unknown>;
     const toolResult = body['result'] as Record<string, unknown>;
     expect(toolResult['isError']).toBe(true);

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -454,46 +454,46 @@ describe('handleCaptureNote', () => {
   beforeEach(() => { vi.clearAllMocks(); });
 
   describe('input validation', () => {
-    it('returns error when text is missing', async () => {
+    it('returns error when raw_input is missing', async () => {
       const r = toolResult(await handleCaptureNote({}, mockDb, mockOpenAI, MOCK_CONFIG));
       expect(r.isError).toBe(true);
-      expect(r.content[0]!.text).toMatch(/text is required/);
+      expect(r.content[0]!.text).toMatch(/raw_input is required/);
     });
 
-    it('returns error when text is empty string', async () => {
-      const r = toolResult(await handleCaptureNote({ text: '' }, mockDb, mockOpenAI, MOCK_CONFIG));
+    it('returns error when raw_input is empty string', async () => {
+      const r = toolResult(await handleCaptureNote({ raw_input: '' }, mockDb, mockOpenAI, MOCK_CONFIG));
       expect(r.isError).toBe(true);
     });
 
-    it('returns error when text exceeds 4000 characters', async () => {
-      const r = toolResult(await handleCaptureNote({ text: 'a'.repeat(4001) }, mockDb, mockOpenAI, MOCK_CONFIG));
+    it('returns error when raw_input exceeds 4000 characters', async () => {
+      const r = toolResult(await handleCaptureNote({ raw_input: 'a'.repeat(4001) }, mockDb, mockOpenAI, MOCK_CONFIG));
       expect(r.isError).toBe(true);
       expect(r.content[0]!.text).toMatch(/4000 character/);
     });
 
     it('defaults source to "mcp" when not provided', async () => {
-      await handleCaptureNote({ text: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG);
+      await handleCaptureNote({ raw_input: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG);
       expect(vi.mocked(insertNote)).toHaveBeenCalledWith(
         mockDb, expect.any(Object), expect.any(Array), 'hello', 'mcp',
       );
     });
 
     it('defaults source to "mcp" when source fails SOURCE_RE pattern', async () => {
-      await handleCaptureNote({ text: 'hello', source: 'bad source!' }, mockDb, mockOpenAI, MOCK_CONFIG);
+      await handleCaptureNote({ raw_input: 'hello', source: 'bad source!' }, mockDb, mockOpenAI, MOCK_CONFIG);
       expect(vi.mocked(insertNote)).toHaveBeenCalledWith(
         mockDb, expect.any(Object), expect.any(Array), 'hello', 'mcp',
       );
     });
 
     it('defaults source to "mcp" when source exceeds 100 characters', async () => {
-      await handleCaptureNote({ text: 'hello', source: 'a'.repeat(101) }, mockDb, mockOpenAI, MOCK_CONFIG);
+      await handleCaptureNote({ raw_input: 'hello', source: 'a'.repeat(101) }, mockDb, mockOpenAI, MOCK_CONFIG);
       expect(vi.mocked(insertNote)).toHaveBeenCalledWith(
         mockDb, expect.any(Object), expect.any(Array), 'hello', 'mcp',
       );
     });
 
     it('uses the provided source when valid', async () => {
-      await handleCaptureNote({ text: 'hello', source: 'obsidian' }, mockDb, mockOpenAI, MOCK_CONFIG);
+      await handleCaptureNote({ raw_input: 'hello', source: 'obsidian' }, mockDb, mockOpenAI, MOCK_CONFIG);
       expect(vi.mocked(insertNote)).toHaveBeenCalledWith(
         mockDb, expect.any(Object), expect.any(Array), 'hello', 'obsidian',
       );
@@ -502,45 +502,45 @@ describe('handleCaptureNote', () => {
 
   describe('capture pipeline', () => {
     it('embeds text and fetches capture voice (calls both)', async () => {
-      await handleCaptureNote({ text: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG);
+      await handleCaptureNote({ raw_input: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG);
       expect(vi.mocked(embedText)).toHaveBeenCalled();
       expect(vi.mocked(getCaptureVoice)).toHaveBeenCalled();
     });
 
     it('calls findRelatedNotes with raw embedding and config threshold', async () => {
       vi.mocked(embedText).mockResolvedValueOnce([0.1, 0.2]);
-      await handleCaptureNote({ text: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG);
+      await handleCaptureNote({ raw_input: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG);
       expect(vi.mocked(findRelatedNotes)).toHaveBeenCalledWith(mockDb, [0.1, 0.2], MOCK_CONFIG.matchThreshold);
     });
 
     it('calls runCaptureAgent with text and related notes and capture voice', async () => {
       vi.mocked(getCaptureVoice).mockResolvedValueOnce('## Voice rules');
-      await handleCaptureNote({ text: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG);
+      await handleCaptureNote({ raw_input: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG);
       expect(vi.mocked(runCaptureAgent)).toHaveBeenCalledWith(
         mockOpenAI, MOCK_CONFIG, 'hello', [], '## Voice rules',
       );
     });
 
     it('calls embedText a second time for augmented embedding', async () => {
-      await handleCaptureNote({ text: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG);
+      await handleCaptureNote({ raw_input: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG);
       expect(vi.mocked(embedText)).toHaveBeenCalledTimes(2);
     });
 
     it('calls insertNote with augmented embedding', async () => {
       vi.mocked(embedText).mockResolvedValueOnce([0.1]).mockResolvedValueOnce([0.9]);
-      await handleCaptureNote({ text: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG);
+      await handleCaptureNote({ raw_input: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG);
       expect(vi.mocked(insertNote)).toHaveBeenCalledWith(
         mockDb, expect.any(Object), [0.9], 'hello', 'mcp',
       );
     });
 
     it('calls insertLinks after inserting note', async () => {
-      await handleCaptureNote({ text: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG);
+      await handleCaptureNote({ raw_input: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG);
       expect(vi.mocked(insertLinks)).toHaveBeenCalledWith(mockDb, VALID_UUID, []);
     });
 
     it('calls logEnrichments with capture and augmented enrichment types', async () => {
-      await handleCaptureNote({ text: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG);
+      await handleCaptureNote({ raw_input: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG);
       expect(vi.mocked(logEnrichments)).toHaveBeenCalledWith(mockDb, VALID_UUID, [
         { enrichment_type: 'capture', model_used: MOCK_CONFIG.captureModel },
         { enrichment_type: 'augmented', model_used: MOCK_CONFIG.embedModel },
@@ -548,7 +548,7 @@ describe('handleCaptureNote', () => {
     });
 
     it('returns toolSuccess with note details', async () => {
-      const r = toolResult(await handleCaptureNote({ text: 'hello', source: 'obsidian' }, mockDb, mockOpenAI, MOCK_CONFIG));
+      const r = toolResult(await handleCaptureNote({ raw_input: 'hello', source: 'obsidian' }, mockDb, mockOpenAI, MOCK_CONFIG));
       expect(r.isError).toBe(false);
       const body = JSON.parse(r.content[0]!.text);
       expect(body.id).toBe(VALID_UUID);
@@ -563,7 +563,7 @@ describe('handleCaptureNote', () => {
       vi.mocked(embedText)
         .mockResolvedValueOnce([0.1, 0.2]) // raw embed — success
         .mockRejectedValueOnce(new Error('embed failed')); // augmented embed — fail
-      const r = toolResult(await handleCaptureNote({ text: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG));
+      const r = toolResult(await handleCaptureNote({ raw_input: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG));
       // Should still succeed — note not lost
       expect(r.isError).toBe(false);
       // insertNote called with raw embedding [0.1, 0.2]
@@ -576,7 +576,7 @@ describe('handleCaptureNote', () => {
       vi.mocked(embedText)
         .mockResolvedValueOnce([0.1])
         .mockRejectedValueOnce(new Error('embed failed'));
-      await handleCaptureNote({ text: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG);
+      await handleCaptureNote({ raw_input: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG);
       expect(vi.mocked(logEnrichments)).toHaveBeenCalledWith(mockDb, expect.any(String), [
         { enrichment_type: 'capture', model_used: MOCK_CONFIG.captureModel },
         { enrichment_type: 'raw_fallback', model_used: MOCK_CONFIG.embedModel },
@@ -587,19 +587,19 @@ describe('handleCaptureNote', () => {
   describe('error handling', () => {
     it('returns toolError when first embedText throws', async () => {
       vi.mocked(embedText).mockRejectedValueOnce(new Error('API down'));
-      const r = toolResult(await handleCaptureNote({ text: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG));
+      const r = toolResult(await handleCaptureNote({ raw_input: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG));
       expect(r.isError).toBe(true);
     });
 
     it('returns toolError when runCaptureAgent throws', async () => {
       vi.mocked(runCaptureAgent).mockRejectedValueOnce(new Error('LLM error'));
-      const r = toolResult(await handleCaptureNote({ text: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG));
+      const r = toolResult(await handleCaptureNote({ raw_input: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG));
       expect(r.isError).toBe(true);
     });
 
     it('returns toolError when insertNote throws', async () => {
       vi.mocked(insertNote).mockRejectedValueOnce(new Error('DB error'));
-      const r = toolResult(await handleCaptureNote({ text: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG));
+      const r = toolResult(await handleCaptureNote({ raw_input: 'hello' }, mockDb, mockOpenAI, MOCK_CONFIG));
       expect(r.isError).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary

- Renamed the `capture_note` parameter from `text` to `raw_input`
- Description now explicitly mentions the required parameter name: "Required parameter: raw_input (the user's verbatim words)"
- Error messages updated to reference `raw_input`
- All tests updated (93 unit + 35 index + 24 smoke = 152 tests passing)

## Context

Real-world testing with Claude Code CLI showed the agent's first call failed — it guessed `raw_input` as the parameter name because the PR #49 description says "raw input" repeatedly while the parameter was called `text`. The agent pattern-matched on the description and got the wrong name.

`raw_input` is the better name anyway: it tells the agent what to put in (verbatim user words), matches the `notes.raw_input` DB column, and aligns with the description language.

## Test plan

- [x] `npx tsc --noEmit -p mcp/tsconfig.json` — typecheck clean
- [x] `npx vitest run tests/mcp-tools.test.ts tests/mcp-index.test.ts` — 128 unit tests pass
- [x] Deployed to live MCP Worker, verified `tools/list` shows `raw_input` parameter
- [x] `npx vitest run tests/mcp-smoke.test.ts` — 24 smoke tests pass (including live capture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)