### PR TITLE
feat: capture agent tuning from real-world usage testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,7 +274,7 @@ The LLM returns this JSON and nothing else:
   "modality": "text|link|list|mixed",
   "entities": [{"name": "...", "type": "person|place|tool|project|concept"}],
   "links": [
-    { "to_id": "<uuid>", "link_type": "extends|contradicts|supports|is-example-of" }
+    { "to_id": "<uuid>", "link_type": "extends|contradicts|supports|is-example-of|duplicate-of" }
   ]
 }
 ```
@@ -285,7 +285,7 @@ The LLM returns this JSON and nothing else:
 
 **Type and intent are independent facets** — a `source` note can have `plan` intent, a `reflection` can have `remember` intent.
 
-**Link types:** `extends` = builds on/deepens; `contradicts` = challenges; `supports` = reinforces or parallel/sibling idea toward same goal; `is-example-of` = concrete instance.
+**Link types:** `extends` = builds on/deepens; `contradicts` = challenges; `supports` = reinforces or parallel/sibling idea toward same goal; `is-example-of` = concrete instance; `duplicate-of` = covers substantially the same content as an existing note (note is still created; deduplication is a gardening concern).
 
 **Entity extraction:** proper nouns only, explicitly in the input — not from related notes, not from training data. Use corrected name from `corrections` field if applicable.
 
@@ -293,7 +293,7 @@ The LLM returns this JSON and nothing else:
 
 8 tables total:
 - `notes` — core notes with 9 new v2 columns (intent, modality, entities, corrections, summary, refined_tags, categories, metadata, importance_score, maturity, archived_at, embedding, embedded_at, content_tsv)
-- `links` — 8 link types (4 capture-time + 4 gardening-time); includes context, confidence, created_by
+- `links` — 9 link types (5 capture-time + 4 gardening-time); includes context, confidence, created_by
 - `concepts` — SKOS controlled vocabulary (scheme, pref_label, alt_labels, definition, embedding)
 - `note_concepts` — junction: notes ↔ concepts
 - `note_chunks` — RAG chunks for long notes (deferred to gardening pipeline)

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The MCP Worker exposes eight tools:
 | `search_chunks` | Search within paragraphs of long notes (body > 1500 chars). Optional: `limit`, `threshold`. |
 | `get_note` | Fetch a single note by UUID — body, raw_input (source of truth), entities, links, corrections. |
 | `list_recent` | Most recent notes, newest first. Optional: `limit`, `filter_type`, `filter_intent`. |
-| `get_related` | Linked notes in both directions with link type glossary (extends, contradicts, supports, is-example-of, is-similar-to). |
+| `get_related` | Linked notes in both directions with link type glossary (extends, contradicts, supports, is-example-of, duplicate-of, is-similar-to). |
 | `capture_note` | Pass the user's raw words — the server runs the full capture pipeline. Do not pre-structure or summarize. |
 | `list_unmatched_tags` | Tags without SKOS concept matches, with frequency. Part of the curation workflow. |
 | `promote_concept` | Add a concept to the SKOS vocabulary. Confirm with the user first; include alt_labels for synonym collapse. |
@@ -295,7 +295,7 @@ npx vitest run tests/gardener-integration.test.ts
 wrangler dev
 ```
 
-~391 tests total across unit, integration, and smoke suites. Smoke and integration tests create and clean up test notes automatically.
+~393 tests total across unit, integration, and smoke suites. Smoke and integration tests create and clean up test notes automatically.
 
 ## Project layout
 

--- a/docs/capture-agent.md
+++ b/docs/capture-agent.md
@@ -53,6 +53,7 @@ The agent receives the top 5 semantically related notes (with their titles, bodi
 | `contradicts` | Challenges or stands in tension with a prior note |
 | `supports` | Reinforces, provides evidence for, or runs parallel toward the same goal |
 | `is-example-of` | A concrete instance of a more abstract prior note |
+| `duplicate-of` | Covers substantially the same content as an existing note — same topic, detail, angle. The note is still created; deduplication is a gardening concern. |
 
 `supports` was broadened after real usage showed that sibling projects (e.g., two kitchen improvement ideas) weren't being linked because none of the original four types fit cleanly. Now `supports` covers both "provides evidence for" and "is a parallel effort toward the same goal."
 
@@ -74,7 +75,7 @@ Four additional types are assigned by the gardener Worker, not the capture agent
 The system prompt instructs the LLM to:
 
 1. Scan for words that are likely voice transcription errors (wrong homophones, out-of-place words)
-2. Cross-reference proper nouns against the related notes provided as context
+2. Cross-reference proper nouns against the related notes provided as context. If a common word in the input is phonetically similar to a domain-specific term in the related notes, and the surrounding context (entities, materials, techniques) favors the domain term, prefer it.
 3. Silently apply corrections in the title and body
 4. Report all corrections in the `corrections` field as `"garbled → corrected"` pairs
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -455,3 +455,13 @@ The `metadata` JSONB column on `enrichment_log` (added in `20260310000000_tag_no
 **Decision (2026-03-10):** `CREATE OR REPLACE FUNCTION` cannot change the return type of an existing function. When extending return columns, `DROP FUNCTION IF EXISTS` must precede `CREATE FUNCTION`.
 
 **Why:** Migration `20260310000003_fix_match_chunks.sql` initially used `CREATE OR REPLACE` to add `note_type`, `note_intent`, `note_tags` columns to `match_chunks`. PostgreSQL rejected this with `cannot change return type of existing function (SQLSTATE 42P13)`. Fixed by adding `DROP FUNCTION IF EXISTS match_chunks` before `CREATE FUNCTION`. Safe because `note_chunks` table was empty at migration time.
+
+## Capture tuning from real-world usage testing (2026-03-11)
+
+Three SYSTEM_FRAME changes based on a 6-note test battery using real Obsidian vault content with deliberately degraded voice input.
+
+**1. `duplicate-of` link type added.** When a note covers substantially the same content as an existing note (same topic, detail, angle), the capture agent now links with `duplicate-of` instead of `supports`. The note is still created — deduplication is a gardening concern, not a capture concern. Previously, identical-title notes were linked as `supports`, giving the caller no signal that deduplication might be warranted.
+
+**2. Voice correction strengthened for real-word substitutions.** The hardest class of voice error is a real word that's wrong in context (e.g., "cymbal" when the user means "cimbalom"). The correction instructions now explicitly tell the LLM: if a common word is phonetically similar to a domain-specific term in the related notes, and surrounding context favors the domain term, prefer it. This won't catch every case — Haiku may still miss subtle ones — but the instruction makes the expectation explicit.
+
+**3. Lookup intent clarified.** `lookup` type notes were getting `intent: reference`, but a research question ("look into whether X works") has no URL and isn't saving someone else's work. Added explicit guidance: lookup notes typically get `plan` or `remember` intent, not `reference`.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -64,7 +64,7 @@ Typed edges between notes. Capture-time links are created by the LLM; gardening-
 | `created_at` | timestamptz | |
 
 **Link types:**
-- Capture-time: `extends`, `contradicts`, `supports`, `is-example-of`
+- Capture-time: `extends`, `contradicts`, `supports`, `is-example-of`, `duplicate-of`
 - Gardening-time: `is-similar-to` (live), `is-part-of`, `follows`, `is-derived-from`
 
 **Unique constraint:** `(from_id, to_id, link_type)` — prevents duplicate links of the same type between the same pair.

--- a/mcp/src/capture.ts
+++ b/mcp/src/capture.ts
@@ -11,7 +11,7 @@ const SYSTEM_FRAME = `You are a knowledge capture agent. Transform raw input int
 
 Input may come from voice dictation or quick typing. Before anything else:
 1. Scan for misspellings and out-of-place words — phonetically plausible but wrong in context, or simply misspelled.
-2. Cross-reference related notes for proper nouns, tool names, project names.
+2. Cross-reference related notes for proper nouns, tool names, project names. If a common word in the input is phonetically similar to a domain-specific term that appears in the related notes, and the surrounding context (other entities, materials, techniques) matches the related note better than the common word, prefer the domain-specific term.
 3. Silently correct in the output. Report in the \`corrections\` field (e.g., \`["cattle stitch → kettle stitch"]\`, \`["caleidoscope → kaleidoscope"]\`). Use null if nothing was corrected.
 
 ## Classification rules
@@ -34,6 +34,7 @@ Input may come from voice dictation or quick typing. Before anything else:
 - \`reference\` — saving external content: articles, links, quotes, or bookmarks. Use when a URL is present or the user is explicitly saving someone else's work.
 - \`log\` — recording what happened (events, completions, milestones)
 If the input could be \`remember\` or \`reference\`, use \`remember\` when no URL is present, \`reference\` when a URL is present.
+For \`lookup\` type notes, the intent is typically \`plan\` (research to inform a future action) or \`remember\` (storing a question for later). It is not \`reference\` unless a URL is present.
 
 **Type and intent are independent.** Type describes the *form* of the note (is it an idea, a reflection, a source reference, or a research prompt?). Intent describes *what the user is doing* (planning, reflecting, creating, remembering, etc.). A \`source\` type note can have \`plan\` intent (saving a link to act on later). A \`reflection\` type note can have \`remember\` intent (recording a personal realization for future reference). Do not assume they must match.
 
@@ -53,11 +54,12 @@ Each entity has a name and type:
 Return an empty array if no clear named entities appear in the input.
 
 **Links**: for each related note provided, decide if a typed relationship applies.
-Types: \`extends | contradicts | supports | is-example-of\`
+Types: \`extends | contradicts | supports | is-example-of | duplicate-of\`
 - \`extends\` — builds on, deepens, or expands the other note's idea
 - \`contradicts\` — challenges or is in tension with it
 - \`supports\` — provides evidence, reinforces, or is a parallel/sibling idea toward the same goal
 - \`is-example-of\` — a concrete instance of the other note's concept
+- \`duplicate-of\` — the new note covers substantially the same content as the related note. Use when the topic, detail level, and angle are the same, not merely related. Still create the note — deduplication is a gardening concern, not a capture concern.
 Prefer more links over fewer. It is fine to link to zero notes.
 
 If the input is too short to form a full note, do your best. Do not ask for clarification.
@@ -74,7 +76,7 @@ Return valid JSON only. No text outside the JSON object.
   "modality": "text|link|list|mixed",
   "entities": [{"name": "...", "type": "person|place|tool|project|concept"}],
   "links": [
-    { "to_id": "<uuid>", "link_type": "extends|contradicts|supports|is-example-of" }
+    { "to_id": "<uuid>", "link_type": "extends|contradicts|supports|is-example-of|duplicate-of" }
   ]
 }`;
 
@@ -88,7 +90,7 @@ function buildSystemPrompt(captureVoice: string): string {
 }
 
 const VALID_NOTE_TYPES: readonly NoteType[] = ['idea', 'reflection', 'source', 'lookup'];
-const VALID_LINK_TYPES: readonly CaptureLinkType[] = ['extends', 'contradicts', 'supports', 'is-example-of'];
+const VALID_LINK_TYPES: readonly CaptureLinkType[] = ['extends', 'contradicts', 'supports', 'is-example-of', 'duplicate-of'];
 const VALID_INTENTS: readonly Intent[] = ['reflect', 'plan', 'create', 'remember', 'reference', 'log'];
 const VALID_MODALITIES: readonly Modality[] = ['text', 'link', 'list', 'mixed'];
 const VALID_ENTITY_TYPES = ['person', 'place', 'tool', 'project', 'concept'] as const;

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -70,7 +70,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'get_related',
-    description: 'Get all notes linked to a given note, in both directions. Link types: extends (builds on), contradicts (challenges), supports (reinforces or parallel effort), is-example-of (concrete instance), is-similar-to (auto-detected by gardener). The direction field shows whether the queried note is source (outbound) or target (inbound). created_by distinguishes capture-time links from gardener-detected ones.',
+    description: 'Get all notes linked to a given note, in both directions. Link types: extends (builds on), contradicts (challenges), supports (reinforces or parallel effort), is-example-of (concrete instance), duplicate-of (same content as existing note), is-similar-to (auto-detected by gardener). The direction field shows whether the queried note is source (outbound) or target (inbound). created_by distinguishes capture-time links from gardener-detected ones.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/mcp/src/types.ts
+++ b/mcp/src/types.ts
@@ -16,7 +16,7 @@ export interface Env {
 export type NoteType = 'idea' | 'reflection' | 'source' | 'lookup';
 
 // Capture-time link types (LLM-assigned)
-export type CaptureLinkType = 'extends' | 'contradicts' | 'supports' | 'is-example-of';
+export type CaptureLinkType = 'extends' | 'contradicts' | 'supports' | 'is-example-of' | 'duplicate-of';
 
 // All link types (capture + gardening)
 export type LinkType = CaptureLinkType

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -11,7 +11,7 @@ const SYSTEM_FRAME = `You are a knowledge capture agent. Transform raw input int
 
 Input may come from voice dictation or quick typing. Before anything else:
 1. Scan for misspellings and out-of-place words — phonetically plausible but wrong in context, or simply misspelled.
-2. Cross-reference related notes for proper nouns, tool names, project names.
+2. Cross-reference related notes for proper nouns, tool names, project names. If a common word in the input is phonetically similar to a domain-specific term that appears in the related notes, and the surrounding context (other entities, materials, techniques) matches the related note better than the common word, prefer the domain-specific term.
 3. Silently correct in the output. Report in the \`corrections\` field (e.g., \`["cattle stitch → kettle stitch"]\`, \`["caleidoscope → kaleidoscope"]\`). Use null if nothing was corrected.
 
 ## Classification rules
@@ -34,6 +34,7 @@ Input may come from voice dictation or quick typing. Before anything else:
 - \`reference\` — saving external content: articles, links, quotes, or bookmarks. Use when a URL is present or the user is explicitly saving someone else's work.
 - \`log\` — recording what happened (events, completions, milestones)
 If the input could be \`remember\` or \`reference\`, use \`remember\` when no URL is present, \`reference\` when a URL is present.
+For \`lookup\` type notes, the intent is typically \`plan\` (research to inform a future action) or \`remember\` (storing a question for later). It is not \`reference\` unless a URL is present.
 
 **Type and intent are independent.** Type describes the *form* of the note (is it an idea, a reflection, a source reference, or a research prompt?). Intent describes *what the user is doing* (planning, reflecting, creating, remembering, etc.). A \`source\` type note can have \`plan\` intent (saving a link to act on later). A \`reflection\` type note can have \`remember\` intent (recording a personal realization for future reference). Do not assume they must match.
 
@@ -53,11 +54,12 @@ Each entity has a name and type:
 Return an empty array if no clear named entities appear in the input.
 
 **Links**: for each related note provided, decide if a typed relationship applies.
-Types: \`extends | contradicts | supports | is-example-of\`
+Types: \`extends | contradicts | supports | is-example-of | duplicate-of\`
 - \`extends\` — builds on, deepens, or expands the other note's idea
 - \`contradicts\` — challenges or is in tension with it
 - \`supports\` — provides evidence, reinforces, or is a parallel/sibling idea toward the same goal
 - \`is-example-of\` — a concrete instance of the other note's concept
+- \`duplicate-of\` — the new note covers substantially the same content as the related note. Use when the topic, detail level, and angle are the same, not merely related. Still create the note — deduplication is a gardening concern, not a capture concern.
 Prefer more links over fewer. It is fine to link to zero notes.
 
 If the input is too short to form a full note, do your best. Do not ask for clarification.
@@ -74,7 +76,7 @@ Return valid JSON only. No text outside the JSON object.
   "modality": "text|link|list|mixed",
   "entities": [{"name": "...", "type": "person|place|tool|project|concept"}],
   "links": [
-    { "to_id": "<uuid>", "link_type": "extends|contradicts|supports|is-example-of" }
+    { "to_id": "<uuid>", "link_type": "extends|contradicts|supports|is-example-of|duplicate-of" }
   ]
 }`;
 
@@ -88,7 +90,7 @@ function buildSystemPrompt(captureVoice: string): string {
 }
 
 const VALID_NOTE_TYPES: readonly NoteType[] = ['idea', 'reflection', 'source', 'lookup'];
-const VALID_LINK_TYPES: readonly CaptureLinkType[] = ['extends', 'contradicts', 'supports', 'is-example-of'];
+const VALID_LINK_TYPES: readonly CaptureLinkType[] = ['extends', 'contradicts', 'supports', 'is-example-of', 'duplicate-of'];
 const VALID_INTENTS: readonly Intent[] = ['reflect', 'plan', 'create', 'remember', 'reference', 'log'];
 const VALID_MODALITIES: readonly Modality[] = ['text', 'link', 'list', 'mixed'];
 const VALID_ENTITY_TYPES = ['person', 'place', 'tool', 'project', 'concept'] as const;

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,7 @@ export interface TelegramUpdate {
 export type NoteType = 'idea' | 'reflection' | 'source' | 'lookup';
 
 // Capture-time link types (LLM-assigned)
-export type CaptureLinkType = 'extends' | 'contradicts' | 'supports' | 'is-example-of';
+export type CaptureLinkType = 'extends' | 'contradicts' | 'supports' | 'is-example-of' | 'duplicate-of';
 
 // All link types (capture + gardening)
 export type LinkType = CaptureLinkType

--- a/tests/mcp-parser.test.ts
+++ b/tests/mcp-parser.test.ts
@@ -125,6 +125,17 @@ describe('parseCaptureResponse — mcp/src/capture.ts', () => {
     expect(result.links[0]!.link_type).toBe('extends');
   });
 
+  it('accepts duplicate-of link type', () => {
+    const result = parseCaptureResponse(make({
+      links: [
+        { to_id: '123', link_type: 'duplicate-of' },
+        { to_id: '456', link_type: 'extends' },
+      ],
+    }));
+    expect(result.links).toHaveLength(2);
+    expect(result.links[0]!.link_type).toBe('duplicate-of');
+  });
+
   it('throws on non-JSON string', () => {
     expect(() => parseCaptureResponse('not json')).toThrow('invalid JSON');
   });

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -118,6 +118,17 @@ describe('parseCaptureResponse', () => {
     expect(result.links[0]!.link_type).toBe('extends');
   });
 
+  it('accepts duplicate-of link type', () => {
+    const result = parseCaptureResponse(make({
+      links: [
+        { to_id: '123', link_type: 'duplicate-of' },
+        { to_id: '456', link_type: 'extends' },
+      ],
+    }));
+    expect(result.links).toHaveLength(2);
+    expect(result.links[0]!.link_type).toBe('duplicate-of');
+  });
+
   it('throws on non-JSON string', () => {
     expect(() => parseCaptureResponse('not json')).toThrow('invalid JSON');
   });


### PR DESCRIPTION
## Summary

Three SYSTEM_FRAME improvements based on a 6-note test battery using real Obsidian vault content with deliberately degraded voice input. Closes #53.

- **`duplicate-of` link type** — When a note covers substantially the same content as an existing note, the capture agent now links with `duplicate-of` instead of `supports`. Note is still created; deduplication is a gardening concern.
- **Voice correction for real-word substitutions** — Strengthened prompt rule: if a common word is phonetically similar to a domain-specific term in the related notes and surrounding context favors the domain term, prefer it. Targets the class of error where a common word replaces a domain-specific term.
- **Lookup intent clarification** — Lookup notes now get `plan` or `remember` intent, not `reference` (which requires a URL).

## Files changed (12)

- `src/capture.ts` + `mcp/src/capture.ts` — SYSTEM_FRAME edits (3 rules) + `VALID_LINK_TYPES` expanded
- `src/types.ts` + `mcp/src/types.ts` — `CaptureLinkType` union includes `duplicate-of`
- `mcp/src/tools.ts` — `get_related` description updated
- `tests/parser.test.ts` + `tests/mcp-parser.test.ts` — new test: `duplicate-of` accepted by parser
- `CLAUDE.md`, `README.md`, `docs/capture-agent.md`, `docs/schema.md`, `docs/decisions.md` — docs updated

## Test plan

- [x] `npx tsc --noEmit` — all three Workers typecheck
- [x] `npx vitest run tests/parser.test.ts tests/mcp-parser.test.ts` — 36 tests pass (18+18, +2 new)
- [ ] Deploy and re-run the 6-note test battery to verify `duplicate-of` is emitted for near-duplicates
- [ ] Verify voice correction of domain-specific terms with the strengthened prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)