### PR TITLE
fix: strengthen duplicate-of heuristic and broaden lookup detection

### DIFF
--- a/docs/capture-agent.md
+++ b/docs/capture-agent.md
@@ -11,7 +11,7 @@ The capture agent is an LLM that turns raw user input into a structured note. It
 | `idea` | Default. A thought, observation, or plan that doesn't fit the other three. |
 | `reflection` | First-person personal insight. Requires an explicit signal of personal resonance — "this resonates with me", "I realized", "I felt". Topic alone is never enough; a note *about* mindfulness is not automatically a reflection. |
 | `source` | An external URL is included in the input. |
-| `lookup` | An investigative prompt — the user is asking a question to research later, not recording an answer. |
+| `lookup` | An investigative prompt — the user is asking a question to research later, not recording an answer. Triggered by investigative framing ("look into", "figure out whether", "check out"), even if the subject involves something buildable. |
 
 ### Intent — what the user is doing
 
@@ -53,7 +53,7 @@ The agent receives the top 5 semantically related notes (with their titles, bodi
 | `contradicts` | Challenges or stands in tension with a prior note |
 | `supports` | Reinforces, provides evidence for, or runs parallel toward the same goal |
 | `is-example-of` | A concrete instance of a more abstract prior note |
-| `duplicate-of` | Covers substantially the same content as an existing note — same topic, detail, angle. The note is still created; deduplication is a gardening concern. |
+| `duplicate-of` | Covers substantially the same content as an existing note — same topic, detail, angle. Heuristic: if the new note would get the same or nearly identical title as the related note, it's a duplicate. Use `duplicate-of`, not `supports`. The note is still created; deduplication is a gardening concern. |
 
 `supports` was broadened after real usage showed that sibling projects (e.g., two kitchen improvement ideas) weren't being linked because none of the original four types fit cleanly. Now `supports` covers both "provides evidence for" and "is a parallel effort toward the same goal."
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -465,3 +465,13 @@ Three SYSTEM_FRAME changes based on a 6-note test battery using real Obsidian va
 **2. Voice correction strengthened for real-word substitutions.** The hardest class of voice error is a real word that's wrong in context (e.g., "cymbal" when the user means "cimbalom"). The correction instructions now explicitly tell the LLM: if a common word is phonetically similar to a domain-specific term in the related notes, and surrounding context favors the domain term, prefer it. This won't catch every case — Haiku may still miss subtle ones — but the instruction makes the expectation explicit.
 
 **3. Lookup intent clarified.** `lookup` type notes were getting `intent: reference`, but a research question ("look into whether X works") has no URL and isn't saving someone else's work. Added explicit guidance: lookup notes typically get `plan` or `remember` intent, not `reference`.
+
+## Capture tuning round 2 (2026-03-11)
+
+Follow-up from Battery 2 testing. Two prompt refinements.
+
+**1. `duplicate-of` heuristic strengthened.** Battery 2 Test 1 confirmed the LLM didn't fire `duplicate-of` despite same concept/angle — it defaulted to `supports`. Added a concrete observable test: "if you would give the new note the same or nearly identical title as the related note, it is a duplicate. Use `duplicate-of`, not `supports`." The title-matching heuristic gives the LLM something to check rather than asking it to judge abstract sameness.
+
+**2. `lookup` type detection broadened.** "Figure out whether" didn't trigger `lookup` in Battery 2 (classified as `idea`/`create` instead), while "look into whether" did in Battery 1. Removed the "Not for things to make or build" exclusion — a research question about something buildable is still a lookup if the framing is investigative. Added "figure out whether Y" to the examples. Key signal is now the opening verb phrase, not the domain.
+
+**Known limitation documented: real-word voice errors without corpus support.** "Guitar" for "citera" went uncorrected because no citera note exists in the corpus. The voice correction cross-references related notes, but can only correct to terms that appear in the context. When the domain-specific term isn't in the corpus at all, the LLM would need its own training knowledge to make the inference — which is unreliable for obscure terms. This is accepted as a known limitation.

--- a/mcp/src/capture.ts
+++ b/mcp/src/capture.ts
@@ -18,7 +18,7 @@ Input may come from voice dictation or quick typing. Before anything else:
 
 **Type**: one of \`idea | reflection | source | lookup\`
 - \`reflection\` — first-person, personal insight. Only when the user's words **explicitly** signal personal resonance ("this resonates with me", "I've always felt this"). Never infer from topic alone. When in doubt, use \`idea\`.
-- \`lookup\` — primarily a research or investigation prompt ("look into X", "check out Y"). Not for things to make or build.
+- \`lookup\` — primarily a research or investigation prompt ("look into X", "figure out whether Y", "check out Z"). Use when the opening phrase frames a question to investigate, even if the subject involves something buildable. The key signal is investigative framing, not the domain.
 - \`source\` — from an external source with a URL.
 - \`idea\` — everything else. Default. Neutral voice.
 
@@ -59,7 +59,7 @@ Types: \`extends | contradicts | supports | is-example-of | duplicate-of\`
 - \`contradicts\` — challenges or is in tension with it
 - \`supports\` — provides evidence, reinforces, or is a parallel/sibling idea toward the same goal
 - \`is-example-of\` — a concrete instance of the other note's concept
-- \`duplicate-of\` — the new note covers substantially the same content as the related note. Use when the topic, detail level, and angle are the same, not merely related. Still create the note — deduplication is a gardening concern, not a capture concern.
+- \`duplicate-of\` — the new note covers substantially the same content as the related note. Test: if you would give the new note the same or nearly identical title as the related note, it is a duplicate. Use \`duplicate-of\`, not \`supports\`. Still create the note — deduplication is a gardening concern, not a capture concern.
 Prefer more links over fewer. It is fine to link to zero notes.
 
 If the input is too short to form a full note, do your best. Do not ask for clarification.

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -18,7 +18,7 @@ Input may come from voice dictation or quick typing. Before anything else:
 
 **Type**: one of \`idea | reflection | source | lookup\`
 - \`reflection\` — first-person, personal insight. Only when the user's words **explicitly** signal personal resonance ("this resonates with me", "I've always felt this"). Never infer from topic alone. When in doubt, use \`idea\`.
-- \`lookup\` — primarily a research or investigation prompt ("look into X", "check out Y"). Not for things to make or build.
+- \`lookup\` — primarily a research or investigation prompt ("look into X", "figure out whether Y", "check out Z"). Use when the opening phrase frames a question to investigate, even if the subject involves something buildable. The key signal is investigative framing, not the domain.
 - \`source\` — from an external source with a URL.
 - \`idea\` — everything else. Default. Neutral voice.
 
@@ -59,7 +59,7 @@ Types: \`extends | contradicts | supports | is-example-of | duplicate-of\`
 - \`contradicts\` — challenges or is in tension with it
 - \`supports\` — provides evidence, reinforces, or is a parallel/sibling idea toward the same goal
 - \`is-example-of\` — a concrete instance of the other note's concept
-- \`duplicate-of\` — the new note covers substantially the same content as the related note. Use when the topic, detail level, and angle are the same, not merely related. Still create the note — deduplication is a gardening concern, not a capture concern.
+- \`duplicate-of\` — the new note covers substantially the same content as the related note. Test: if you would give the new note the same or nearly identical title as the related note, it is a duplicate. Use \`duplicate-of\`, not \`supports\`. Still create the note — deduplication is a gardening concern, not a capture concern.
 Prefer more links over fewer. It is fine to link to zero notes.
 
 If the input is too short to form a full note, do your best. Do not ask for clarification.


### PR DESCRIPTION
## Summary

Follow-up to PR #54 based on Battery 2 test results. Two prompt refinements:

- **`duplicate-of` heuristic**: Added title-match test — "if you would give the new note the same or nearly identical title as the related note, use `duplicate-of`, not `supports`." Gives the LLM an observable check instead of asking it to judge abstract sameness.
- **`lookup` type detection**: Removed "Not for things to make or build" exclusion. Added "figure out whether Y" to examples. A research question about something buildable is still a lookup if the framing is investigative.

Also documents the known limitation: real-word voice errors without corpus support (e.g., "guitar" for "citera") cannot be corrected when the domain term doesn't appear in any related note.

## Test plan

- [x] Typecheck passes (both Workers)
- [x] 36 parser tests pass (18 × 2 parity)
- [ ] Deploy and re-run Battery 2 Tests 1 and 4 to verify fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)