### PR TITLE
refactor: extract handleMcpRequest + fix timing-vulnerable auth

### DIFF
--- a/mcp/src/auth.ts
+++ b/mcp/src/auth.ts
@@ -1,12 +1,52 @@
 import type { Env } from './types';
 
+/**
+ * Constant-time string comparison.
+ * Uses crypto.subtle.timingSafeEqual (Workers runtime) with a fallback
+ * to a manual constant-time loop (for Node test environments).
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+  const encoder = new TextEncoder();
+  const bufA = encoder.encode(a);
+  const bufB = encoder.encode(b);
+  if (bufA.byteLength !== bufB.byteLength) return false;
+
+  // crypto.subtle.timingSafeEqual exists in Workers but not in Node < 20
+  if (typeof crypto !== 'undefined' && crypto.subtle && typeof (crypto.subtle as unknown as Record<string, unknown>)['timingSafeEqual'] === 'function') {
+    return crypto.subtle.timingSafeEqual(bufA, bufB);
+  }
+
+  // Fallback: manual constant-time comparison
+  let result = 0;
+  for (let i = 0; i < bufA.byteLength; i++) {
+    result |= bufA[i]! ^ bufB[i]!;
+  }
+  return result === 0;
+}
+
+/**
+ * Check whether the request carries a valid static Bearer token.
+ * Uses constant-time comparison to prevent timing attacks.
+ */
+export function isStaticTokenRequest(request: Request, env: Env): boolean {
+  const authHeader = request.headers.get('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return false;
+  const token = authHeader.slice(7);
+  if (!token) return false;
+  return timingSafeEqual(token, env.MCP_API_KEY);
+}
+
+/**
+ * Validate auth and return an error Response if invalid, or null if OK.
+ * Uses constant-time comparison internally.
+ */
 export function validateAuth(request: Request, env: Env): Response | null {
   const authHeader = request.headers.get('Authorization');
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return new Response('Unauthorized', { status: 401 });
   }
   const token = authHeader.slice(7);
-  if (token !== env.MCP_API_KEY) {
+  if (!token || !timingSafeEqual(token, env.MCP_API_KEY)) {
     console.warn(JSON.stringify({ event: 'auth_failed', reason: 'invalid_token' }));
     return new Response('Forbidden', { status: 403 });
   }

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -26,6 +26,100 @@ function jsonRpcResult(id: unknown, result: unknown): Response {
   return jsonResponse({ jsonrpc: '2.0', id, result });
 }
 
+/**
+ * Handle an authenticated MCP JSON-RPC request.
+ * Exported so both the static token bypass and future OAuthProvider can call it.
+ */
+export async function handleMcpRequest(request: Request, env: Env): Promise<Response> {
+  // Parse JSON-RPC body
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json() as Record<string, unknown>;
+  } catch {
+    return jsonRpcError(null, -32700, 'Parse error');
+  }
+
+  if (body['jsonrpc'] !== '2.0' || typeof body['method'] !== 'string') {
+    return jsonRpcError(body['id'] ?? null, -32600, 'Invalid request');
+  }
+
+  // Notifications have no id — return 204, do not respond with JSON-RPC
+  if (body['id'] === undefined) {
+    return new Response(null, { status: 204 });
+  }
+
+  const id = body['id'];
+  const method = body['method'] as string;
+  const params = (body['params'] ?? {}) as Record<string, unknown>;
+
+  // ── Initialize ────────────────────────────────────────────────────────────
+  if (method === 'initialize') {
+    return jsonRpcResult(id, {
+      protocolVersion: '2024-11-05',
+      serverInfo: { name: 'contemplace-mcp', version: '1.0.0' },
+      capabilities: { tools: {} },
+    });
+  }
+
+  // ── Tools list ────────────────────────────────────────────────────────────
+  if (method === 'tools/list') {
+    return jsonRpcResult(id, { tools: TOOL_DEFINITIONS });
+  }
+
+  // ── Tools call ────────────────────────────────────────────────────────────
+  if (method === 'tools/call') {
+    const toolName = params['name'] as string | undefined;
+    const args = (params['arguments'] ?? {}) as Record<string, unknown>;
+
+    if (!toolName) return jsonRpcError(id, -32602, 'Missing tool name');
+
+    let config;
+    try {
+      config = loadConfig(env);
+    } catch (err) {
+      console.error(JSON.stringify({ event: 'config_error', error: String(err) }));
+      return jsonRpcError(id, -32603, 'Server configuration error');
+    }
+
+    const db = createClient(config.supabaseUrl, config.supabaseServiceRoleKey);
+    const openai = createOpenAIClient(config);
+
+    let result: object;
+    switch (toolName) {
+      case 'search_notes':
+        result = await handleSearchNotes(args, db, openai, config);
+        break;
+      case 'get_note':
+        result = await handleGetNote(args, db);
+        break;
+      case 'list_recent':
+        result = await handleListRecent(args, db);
+        break;
+      case 'get_related':
+        result = await handleGetRelated(args, db);
+        break;
+      case 'capture_note':
+        result = await handleCaptureNote(args, db, openai, config);
+        break;
+      case 'list_unmatched_tags':
+        result = await handleListUnmatchedTags(args, db);
+        break;
+      case 'promote_concept':
+        result = await handlePromoteConcept(args, db);
+        break;
+      case 'search_chunks':
+        result = await handleSearchChunks(args, db, openai, config);
+        break;
+      default:
+        return jsonRpcError(id, -32601, `Unknown tool: ${toolName}`);
+    }
+
+    return jsonRpcResult(id, result);
+  }
+
+  return jsonRpcError(id, -32601, 'Method not found');
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     // CORS preflight
@@ -42,92 +136,6 @@ export default {
     const authError = validateAuth(request, env);
     if (authError) return authError;
 
-    // Parse JSON-RPC body
-    let body: Record<string, unknown>;
-    try {
-      body = await request.json() as Record<string, unknown>;
-    } catch {
-      return jsonRpcError(null, -32700, 'Parse error');
-    }
-
-    if (body['jsonrpc'] !== '2.0' || typeof body['method'] !== 'string') {
-      return jsonRpcError(body['id'] ?? null, -32600, 'Invalid request');
-    }
-
-    // Notifications have no id — return 204, do not respond with JSON-RPC
-    if (body['id'] === undefined) {
-      return new Response(null, { status: 204 });
-    }
-
-    const id = body['id'];
-    const method = body['method'] as string;
-    const params = (body['params'] ?? {}) as Record<string, unknown>;
-
-    // ── Initialize ────────────────────────────────────────────────────────────
-    if (method === 'initialize') {
-      return jsonRpcResult(id, {
-        protocolVersion: '2024-11-05',
-        serverInfo: { name: 'contemplace-mcp', version: '1.0.0' },
-        capabilities: { tools: {} },
-      });
-    }
-
-    // ── Tools list ────────────────────────────────────────────────────────────
-    if (method === 'tools/list') {
-      return jsonRpcResult(id, { tools: TOOL_DEFINITIONS });
-    }
-
-    // ── Tools call ────────────────────────────────────────────────────────────
-    if (method === 'tools/call') {
-      const toolName = params['name'] as string | undefined;
-      const args = (params['arguments'] ?? {}) as Record<string, unknown>;
-
-      if (!toolName) return jsonRpcError(id, -32602, 'Missing tool name');
-
-      let config;
-      try {
-        config = loadConfig(env);
-      } catch (err) {
-        console.error(JSON.stringify({ event: 'config_error', error: String(err) }));
-        return jsonRpcError(id, -32603, 'Server configuration error');
-      }
-
-      const db = createClient(config.supabaseUrl, config.supabaseServiceRoleKey);
-      const openai = createOpenAIClient(config);
-
-      let result: object;
-      switch (toolName) {
-        case 'search_notes':
-          result = await handleSearchNotes(args, db, openai, config);
-          break;
-        case 'get_note':
-          result = await handleGetNote(args, db);
-          break;
-        case 'list_recent':
-          result = await handleListRecent(args, db);
-          break;
-        case 'get_related':
-          result = await handleGetRelated(args, db);
-          break;
-        case 'capture_note':
-          result = await handleCaptureNote(args, db, openai, config);
-          break;
-        case 'list_unmatched_tags':
-          result = await handleListUnmatchedTags(args, db);
-          break;
-        case 'promote_concept':
-          result = await handlePromoteConcept(args, db);
-          break;
-        case 'search_chunks':
-          result = await handleSearchChunks(args, db, openai, config);
-          break;
-        default:
-          return jsonRpcError(id, -32601, `Unknown tool: ${toolName}`);
-      }
-
-      return jsonRpcResult(id, result);
-    }
-
-    return jsonRpcError(id, -32601, 'Method not found');
+    return handleMcpRequest(request, env);
   },
 };

--- a/tests/mcp-auth.test.ts
+++ b/tests/mcp-auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { validateAuth } from '../mcp/src/auth';
+import { validateAuth, isStaticTokenRequest } from '../mcp/src/auth';
 import type { Env } from '../mcp/src/types';
 
 const VALID_KEY = 'test-api-key-12345';
@@ -41,13 +41,11 @@ describe('validateAuth', () => {
     expect(result!.status).toBe(403);
   });
 
-  // The Fetch API Headers implementation trims trailing whitespace from header
-  // values, so 'Bearer ' becomes 'Bearer' — which fails the startsWith check
-  // and returns 401 rather than 403.
   it('returns 401 when header value is "Bearer" with no token (trailing space trimmed)', () => {
     const result = validateAuth(makeRequest('Bearer '), MOCK_ENV);
     expect(result).not.toBeNull();
-    // 401 because trimmed value 'Bearer' doesn't match 'Bearer ' prefix check
+    // Fetch API trims header values, so "Bearer " → "Bearer" → fails startsWith check → 401
+    // But if not trimmed, slice(7) is empty → 403. Both are acceptable.
     expect([401, 403]).toContain(result!.status);
   });
 
@@ -63,5 +61,27 @@ describe('validateAuth', () => {
     validateAuth(makeRequest(`Bearer ${VALID_KEY}`), MOCK_ENV);
     expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
+  });
+});
+
+describe('isStaticTokenRequest', () => {
+  it('returns true when Bearer token matches MCP_API_KEY', () => {
+    expect(isStaticTokenRequest(makeRequest(`Bearer ${VALID_KEY}`), MOCK_ENV)).toBe(true);
+  });
+
+  it('returns false when token does not match', () => {
+    expect(isStaticTokenRequest(makeRequest('Bearer wrong-token'), MOCK_ENV)).toBe(false);
+  });
+
+  it('returns false when token has different length', () => {
+    expect(isStaticTokenRequest(makeRequest('Bearer x'), MOCK_ENV)).toBe(false);
+  });
+
+  it('returns false when Authorization header is missing', () => {
+    expect(isStaticTokenRequest(makeRequest(), MOCK_ENV)).toBe(false);
+  });
+
+  it('returns false for non-Bearer scheme', () => {
+    expect(isStaticTokenRequest(makeRequest(`Token ${VALID_KEY}`), MOCK_ENV)).toBe(false);
   });
 });

--- a/tests/mcp-dispatch.test.ts
+++ b/tests/mcp-dispatch.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Tests for handleMcpRequest (mcp/src/index.ts).
+ * JSON-RPC protocol, tool dispatch, and response shapes — independent of auth/routing.
+ *
+ * All tool handlers are mocked — their logic is tested in mcp-tools.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('../mcp/src/tools', () => ({
+  TOOL_DEFINITIONS: [
+    { name: 'search_notes', description: 'Search', inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } },
+    { name: 'get_note', description: 'Get', inputSchema: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] } },
+    { name: 'list_recent', description: 'List', inputSchema: { type: 'object', properties: {} } },
+    { name: 'get_related', description: 'Related', inputSchema: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] } },
+    { name: 'capture_note', description: 'Capture', inputSchema: { type: 'object', properties: { raw_input: { type: 'string' } }, required: ['raw_input'] } },
+    { name: 'list_unmatched_tags', description: 'List unmatched', inputSchema: { type: 'object', properties: {} } },
+    { name: 'promote_concept', description: 'Promote', inputSchema: { type: 'object', properties: { pref_label: { type: 'string' }, scheme: { type: 'string' } }, required: ['pref_label', 'scheme'] } },
+    { name: 'search_chunks', description: 'Search chunks', inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } },
+  ],
+  handleSearchNotes: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{"ok":true}' }], isError: false }),
+  handleGetNote: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{"ok":true}' }], isError: false }),
+  handleListRecent: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{"ok":true}' }], isError: false }),
+  handleGetRelated: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{"ok":true}' }], isError: false }),
+  handleCaptureNote: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{"ok":true}' }], isError: false }),
+  handleListUnmatchedTags: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{"ok":true}' }], isError: false }),
+  handlePromoteConcept: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{"ok":true}' }], isError: false }),
+  handleSearchChunks: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{"ok":true}' }], isError: false }),
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('../mcp/src/embed', () => ({
+  createOpenAIClient: vi.fn().mockReturnValue({}),
+  embedText: vi.fn(),
+  buildEmbeddingInput: vi.fn(),
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+import { handleMcpRequest } from '../mcp/src/index';
+import { handleSearchNotes, handleGetNote, handleListRecent, handleGetRelated, handleCaptureNote, handleListUnmatchedTags, handlePromoteConcept, handleSearchChunks } from '../mcp/src/tools';
+
+const MOCK_TOOL_RESULT = { content: [{ type: 'text', text: '{"ok":true}' }], isError: false };
+
+const MOCK_ENV = {
+  MCP_API_KEY: 'test-mcp-api-key',
+  OPENROUTER_API_KEY: 'or-key',
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_SERVICE_ROLE_KEY: 'service-key',
+  CAPTURE_MODEL: 'anthropic/claude-haiku-4-5',
+  EMBED_MODEL: 'openai/text-embedding-3-small',
+  MATCH_THRESHOLD: '0.60',
+};
+
+function makeRequest(body: string): Request {
+  return new Request('https://worker.example.com/mcp', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  });
+}
+
+function rpcBody(method: string, params?: Record<string, unknown>, id: unknown = 1): string {
+  return JSON.stringify({ jsonrpc: '2.0', method, ...(params && { params }), id });
+}
+
+async function dispatch(method: string, params?: Record<string, unknown>, id: unknown = 1): Promise<Response> {
+  return handleMcpRequest(makeRequest(rpcBody(method, params, id)), MOCK_ENV);
+}
+
+async function parseRpc(res: Response): Promise<Record<string, unknown>> {
+  return res.json() as Promise<Record<string, unknown>>;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('handleMcpRequest — JSON-RPC dispatch', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  describe('JSON-RPC parsing', () => {
+    it('returns -32700 parse error when body is not valid JSON', async () => {
+      const res = await handleMcpRequest(makeRequest('not valid json'), MOCK_ENV);
+      const body = await parseRpc(res);
+      expect((body['error'] as Record<string, unknown>)?.['code']).toBe(-32700);
+    });
+
+    it('returns -32600 when jsonrpc field is not "2.0"', async () => {
+      const res = await handleMcpRequest(
+        makeRequest(JSON.stringify({ jsonrpc: '1.0', method: 'initialize', id: 1 })),
+        MOCK_ENV,
+      );
+      const body = await parseRpc(res);
+      expect((body['error'] as Record<string, unknown>)?.['code']).toBe(-32600);
+    });
+
+    it('returns -32600 when method is not a string', async () => {
+      const res = await handleMcpRequest(
+        makeRequest(JSON.stringify({ jsonrpc: '2.0', method: 42, id: 1 })),
+        MOCK_ENV,
+      );
+      const body = await parseRpc(res);
+      expect((body['error'] as Record<string, unknown>)?.['code']).toBe(-32600);
+    });
+  });
+
+  describe('notifications (no id)', () => {
+    it('returns 204 for a request with no id field', async () => {
+      const res = await handleMcpRequest(
+        makeRequest(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })),
+        MOCK_ENV,
+      );
+      expect(res.status).toBe(204);
+    });
+
+    it('does not call any tool handler for a notification', async () => {
+      await handleMcpRequest(
+        makeRequest(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })),
+        MOCK_ENV,
+      );
+      expect(vi.mocked(handleSearchNotes)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('initialize method', () => {
+    it('returns protocolVersion', async () => {
+      const res = await dispatch('initialize');
+      const body = await parseRpc(res);
+      expect((body['result'] as Record<string, unknown>)?.['protocolVersion']).toBe('2024-11-05');
+    });
+
+    it('returns serverInfo.name', async () => {
+      const res = await dispatch('initialize');
+      const body = await parseRpc(res);
+      const result = body['result'] as Record<string, unknown>;
+      expect((result['serverInfo'] as Record<string, unknown>)?.['name']).toBe('contemplace-mcp');
+    });
+
+    it('includes the request id in the response', async () => {
+      const res = await dispatch('initialize', undefined, 42);
+      const body = await parseRpc(res);
+      expect(body['id']).toBe(42);
+    });
+  });
+
+  describe('tools/list method', () => {
+    it('returns the TOOL_DEFINITIONS array', async () => {
+      const res = await dispatch('tools/list');
+      const body = await parseRpc(res);
+      const tools = (body['result'] as Record<string, unknown>)?.['tools'];
+      expect(Array.isArray(tools)).toBe(true);
+    });
+
+    it('returns exactly 8 tool definitions', async () => {
+      const res = await dispatch('tools/list');
+      const body = await parseRpc(res);
+      const tools = (body['result'] as Record<string, unknown>)?.['tools'] as unknown[];
+      expect(tools).toHaveLength(8);
+    });
+
+    it('each tool definition has name, description, inputSchema', async () => {
+      const res = await dispatch('tools/list');
+      const body = await parseRpc(res);
+      const tools = (body['result'] as Record<string, unknown>)?.['tools'] as Array<Record<string, unknown>>;
+      for (const tool of tools) {
+        expect(tool).toHaveProperty('name');
+        expect(tool).toHaveProperty('description');
+        expect(tool).toHaveProperty('inputSchema');
+      }
+    });
+  });
+
+  describe('tools/call dispatch', () => {
+    it('dispatches to handleSearchNotes for name="search_notes"', async () => {
+      await dispatch('tools/call', { name: 'search_notes', arguments: { query: 'test' } });
+      expect(vi.mocked(handleSearchNotes)).toHaveBeenCalledOnce();
+    });
+
+    it('dispatches to handleGetNote for name="get_note"', async () => {
+      await dispatch('tools/call', { name: 'get_note', arguments: { id: 'aaaaaaaa-0000-0000-0000-000000000001' } });
+      expect(vi.mocked(handleGetNote)).toHaveBeenCalledOnce();
+    });
+
+    it('dispatches to handleListRecent for name="list_recent"', async () => {
+      await dispatch('tools/call', { name: 'list_recent', arguments: {} });
+      expect(vi.mocked(handleListRecent)).toHaveBeenCalledOnce();
+    });
+
+    it('dispatches to handleGetRelated for name="get_related"', async () => {
+      await dispatch('tools/call', { name: 'get_related', arguments: { id: 'aaaaaaaa-0000-0000-0000-000000000001' } });
+      expect(vi.mocked(handleGetRelated)).toHaveBeenCalledOnce();
+    });
+
+    it('dispatches to handleCaptureNote for name="capture_note"', async () => {
+      await dispatch('tools/call', { name: 'capture_note', arguments: { raw_input: 'hello' } });
+      expect(vi.mocked(handleCaptureNote)).toHaveBeenCalledOnce();
+    });
+
+    it('dispatches to handleListUnmatchedTags for name="list_unmatched_tags"', async () => {
+      await dispatch('tools/call', { name: 'list_unmatched_tags', arguments: {} });
+      expect(vi.mocked(handleListUnmatchedTags)).toHaveBeenCalledOnce();
+    });
+
+    it('dispatches to handlePromoteConcept for name="promote_concept"', async () => {
+      await dispatch('tools/call', { name: 'promote_concept', arguments: { pref_label: 'test', scheme: 'domains' } });
+      expect(vi.mocked(handlePromoteConcept)).toHaveBeenCalledOnce();
+    });
+
+    it('dispatches to handleSearchChunks for name="search_chunks"', async () => {
+      await dispatch('tools/call', { name: 'search_chunks', arguments: { query: 'test' } });
+      expect(vi.mocked(handleSearchChunks)).toHaveBeenCalledOnce();
+    });
+
+    it('returns -32601 for an unknown tool name', async () => {
+      const res = await dispatch('tools/call', { name: 'nonexistent_tool', arguments: {} });
+      const body = await parseRpc(res);
+      expect((body['error'] as Record<string, unknown>)?.['code']).toBe(-32601);
+    });
+
+    it('returns -32602 when params.name is missing', async () => {
+      const res = await dispatch('tools/call', { arguments: {} });
+      const body = await parseRpc(res);
+      expect((body['error'] as Record<string, unknown>)?.['code']).toBe(-32602);
+    });
+
+    it('wraps tool result in JSON-RPC result envelope', async () => {
+      const res = await dispatch('tools/call', { name: 'list_recent', arguments: {} });
+      const body = await parseRpc(res);
+      expect(body['jsonrpc']).toBe('2.0');
+      expect(body['result']).toEqual(MOCK_TOOL_RESULT);
+    });
+
+    it('passes arguments to handler (not undefined)', async () => {
+      await dispatch('tools/call', { name: 'search_notes', arguments: { query: 'my query' } });
+      const call = vi.mocked(handleSearchNotes).mock.calls[0]!;
+      expect(call[0]).toEqual({ query: 'my query' });
+    });
+  });
+
+  describe('unknown method', () => {
+    it('returns -32601 for an unrecognised method', async () => {
+      const res = await dispatch('ping');
+      const body = await parseRpc(res);
+      expect((body['error'] as Record<string, unknown>)?.['code']).toBe(-32601);
+    });
+  });
+
+  describe('response shape', () => {
+    it('success responses have Content-Type: application/json', async () => {
+      const res = await dispatch('initialize');
+      expect(res.headers.get('Content-Type')).toContain('application/json');
+    });
+
+    it('success responses include CORS headers', async () => {
+      const res = await dispatch('initialize');
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    });
+
+    it('error responses include jsonrpc, id, and error.code + message', async () => {
+      const res = await dispatch('ping');
+      const body = await parseRpc(res);
+      expect(body['jsonrpc']).toBe('2.0');
+      expect(body['id']).toBe(1);
+      const err = body['error'] as Record<string, unknown>;
+      expect(typeof err['code']).toBe('number');
+      expect(typeof err['message']).toBe('string');
+    });
+  });
+});

--- a/tests/mcp-index.test.ts
+++ b/tests/mcp-index.test.ts
@@ -1,35 +1,23 @@
 /**
- * Tests for the MCP HTTP handler (mcp/src/index.ts).
- * Auth, routing, JSON-RPC protocol, and tool dispatch.
- *
- * All tool handlers are mocked — their logic is tested in mcp-tools.test.ts.
- * Supabase and OpenAI clients are mocked to avoid network calls.
+ * Tests for the MCP HTTP wrapper (mcp/src/index.ts default export).
+ * Auth, routing, and CORS only — JSON-RPC dispatch is tested in mcp-dispatch.test.ts.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
-// NOTE: vi.mock factories are hoisted — no outer-scope variables allowed inside.
-// MOCK_TOOL_RESULT is defined after these calls but used in tests below.
 
 vi.mock('../mcp/src/tools', () => ({
   TOOL_DEFINITIONS: [
     { name: 'search_notes', description: 'Search', inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } },
-    { name: 'get_note', description: 'Get', inputSchema: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] } },
-    { name: 'list_recent', description: 'List', inputSchema: { type: 'object', properties: {} } },
-    { name: 'get_related', description: 'Related', inputSchema: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] } },
-    { name: 'capture_note', description: 'Capture', inputSchema: { type: 'object', properties: { raw_input: { type: 'string' } }, required: ['raw_input'] } },
-    { name: 'list_unmatched_tags', description: 'List unmatched', inputSchema: { type: 'object', properties: {} } },
-    { name: 'promote_concept', description: 'Promote', inputSchema: { type: 'object', properties: { pref_label: { type: 'string' }, scheme: { type: 'string' } }, required: ['pref_label', 'scheme'] } },
-    { name: 'search_chunks', description: 'Search chunks', inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } },
   ],
   handleSearchNotes: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{"ok":true}' }], isError: false }),
-  handleGetNote: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{"ok":true}' }], isError: false }),
-  handleListRecent: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{"ok":true}' }], isError: false }),
-  handleGetRelated: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{"ok":true}' }], isError: false }),
-  handleCaptureNote: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{"ok":true}' }], isError: false }),
-  handleListUnmatchedTags: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{"ok":true}' }], isError: false }),
-  handlePromoteConcept: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{"ok":true}' }], isError: false }),
-  handleSearchChunks: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{"ok":true}' }], isError: false }),
+  handleGetNote: vi.fn(),
+  handleListRecent: vi.fn(),
+  handleGetRelated: vi.fn(),
+  handleCaptureNote: vi.fn(),
+  handleListUnmatchedTags: vi.fn(),
+  handlePromoteConcept: vi.fn(),
+  handleSearchChunks: vi.fn(),
 }));
 
 vi.mock('@supabase/supabase-js', () => ({
@@ -44,11 +32,6 @@ vi.mock('../mcp/src/embed', () => ({
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 import handler from '../mcp/src/index';
-import { handleSearchNotes, handleGetNote, handleListRecent, handleGetRelated, handleCaptureNote, handleListUnmatchedTags, handlePromoteConcept, handleSearchChunks } from '../mcp/src/tools';
-
-const MOCK_TOOL_RESULT = { content: [{ type: 'text', text: '{"ok":true}' }], isError: false };
-
-// ── Fixtures ──────────────────────────────────────────────────────────────────
 
 const VALID_API_KEY = 'test-mcp-api-key';
 
@@ -69,28 +52,13 @@ function authHeaders(key = VALID_API_KEY): Record<string, string> {
   };
 }
 
-function rpcBody(method: string, params?: Record<string, unknown>, id: unknown = 1): string {
-  return JSON.stringify({ jsonrpc: '2.0', method, ...(params && { params }), id });
-}
-
-async function post(body: string, headers = authHeaders()): Promise<Response> {
-  return handler.fetch(
-    new Request('https://worker.example.com/mcp', { method: 'POST', headers, body }),
-    MOCK_ENV,
-  );
-}
-
-async function rpc(method: string, params?: Record<string, unknown>, id: unknown = 1): Promise<Response> {
-  return post(rpcBody(method, params, id));
-}
-
-async function parseRpc(res: Response): Promise<Record<string, unknown>> {
-  return res.json() as Promise<Record<string, unknown>>;
+function rpcBody(method: string, id: unknown = 1): string {
+  return JSON.stringify({ jsonrpc: '2.0', method, id });
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
-describe('MCP HTTP handler', () => {
+describe('MCP HTTP wrapper', () => {
   beforeEach(() => { vi.clearAllMocks(); });
 
   describe('CORS preflight', () => {
@@ -151,191 +119,43 @@ describe('MCP HTTP handler', () => {
     });
 
     it('returns 403 when token is wrong', async () => {
-      const res = await post(rpcBody('initialize'), authHeaders('wrong-key'));
+      const res = await handler.fetch(
+        new Request('https://worker.example.com/mcp', {
+          method: 'POST',
+          headers: authHeaders('wrong-key'),
+          body: rpcBody('initialize'),
+        }),
+        MOCK_ENV,
+      );
       expect(res.status).toBe(403);
     });
 
     it('allows request through with correct token', async () => {
-      const res = await rpc('initialize');
+      const res = await handler.fetch(
+        new Request('https://worker.example.com/mcp', {
+          method: 'POST',
+          headers: authHeaders(),
+          body: rpcBody('initialize'),
+        }),
+        MOCK_ENV,
+      );
       expect(res.status).toBe(200);
     });
   });
 
-  describe('JSON-RPC parsing', () => {
-    it('returns -32700 parse error when body is not valid JSON', async () => {
-      const res = await post('not valid json');
-      expect(res.status).toBe(200);
-      const body = await parseRpc(res);
-      expect((body['error'] as Record<string, unknown>)?.['code']).toBe(-32700);
-    });
-
-    it('returns -32600 when jsonrpc field is not "2.0"', async () => {
-      const res = await post(JSON.stringify({ jsonrpc: '1.0', method: 'initialize', id: 1 }));
-      const body = await parseRpc(res);
-      expect((body['error'] as Record<string, unknown>)?.['code']).toBe(-32600);
-    });
-
-    it('returns -32600 when method is not a string', async () => {
-      const res = await post(JSON.stringify({ jsonrpc: '2.0', method: 42, id: 1 }));
-      const body = await parseRpc(res);
-      expect((body['error'] as Record<string, unknown>)?.['code']).toBe(-32600);
-    });
-  });
-
-  describe('notifications (no id)', () => {
-    it('returns 204 for a request with no id field', async () => {
-      const res = await post(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }));
-      expect(res.status).toBe(204);
-    });
-
-    it('does not call any tool handler for a notification', async () => {
-      await post(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }));
-      expect(vi.mocked(handleSearchNotes)).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('initialize method', () => {
-    it('returns protocolVersion', async () => {
-      const res = await rpc('initialize');
-      const body = await parseRpc(res);
-      expect((body['result'] as Record<string, unknown>)?.['protocolVersion']).toBe('2024-11-05');
-    });
-
-    it('returns serverInfo.name', async () => {
-      const res = await rpc('initialize');
-      const body = await parseRpc(res);
-      const result = body['result'] as Record<string, unknown>;
-      expect((result['serverInfo'] as Record<string, unknown>)?.['name']).toBe('contemplace-mcp');
-    });
-
-    it('includes the request id in the response', async () => {
-      const res = await rpc('initialize', undefined, 42);
-      const body = await parseRpc(res);
-      expect(body['id']).toBe(42);
-    });
-  });
-
-  describe('tools/list method', () => {
-    it('returns the TOOL_DEFINITIONS array', async () => {
-      const res = await rpc('tools/list');
-      const body = await parseRpc(res);
-      const tools = (body['result'] as Record<string, unknown>)?.['tools'];
-      expect(Array.isArray(tools)).toBe(true);
-    });
-
-    it('returns exactly 7 tool definitions', async () => {
-      const res = await rpc('tools/list');
-      const body = await parseRpc(res);
-      const tools = (body['result'] as Record<string, unknown>)?.['tools'] as unknown[];
-      expect(tools).toHaveLength(8);
-    });
-
-    it('each tool definition has name, description, inputSchema', async () => {
-      const res = await rpc('tools/list');
-      const body = await parseRpc(res);
-      const tools = (body['result'] as Record<string, unknown>)?.['tools'] as Array<Record<string, unknown>>;
-      for (const tool of tools) {
-        expect(tool).toHaveProperty('name');
-        expect(tool).toHaveProperty('description');
-        expect(tool).toHaveProperty('inputSchema');
-      }
-    });
-  });
-
-  describe('tools/call dispatch', () => {
-    it('dispatches to handleSearchNotes for name="search_notes"', async () => {
-      await rpc('tools/call', { name: 'search_notes', arguments: { query: 'test' } });
-      expect(vi.mocked(handleSearchNotes)).toHaveBeenCalledOnce();
-    });
-
-    it('dispatches to handleGetNote for name="get_note"', async () => {
-      await rpc('tools/call', { name: 'get_note', arguments: { id: 'aaaaaaaa-0000-0000-0000-000000000001' } });
-      expect(vi.mocked(handleGetNote)).toHaveBeenCalledOnce();
-    });
-
-    it('dispatches to handleListRecent for name="list_recent"', async () => {
-      await rpc('tools/call', { name: 'list_recent', arguments: {} });
-      expect(vi.mocked(handleListRecent)).toHaveBeenCalledOnce();
-    });
-
-    it('dispatches to handleGetRelated for name="get_related"', async () => {
-      await rpc('tools/call', { name: 'get_related', arguments: { id: 'aaaaaaaa-0000-0000-0000-000000000001' } });
-      expect(vi.mocked(handleGetRelated)).toHaveBeenCalledOnce();
-    });
-
-    it('dispatches to handleCaptureNote for name="capture_note"', async () => {
-      await rpc('tools/call', { name: 'capture_note', arguments: { raw_input: 'hello' } });
-      expect(vi.mocked(handleCaptureNote)).toHaveBeenCalledOnce();
-    });
-
-    it('dispatches to handleListUnmatchedTags for name="list_unmatched_tags"', async () => {
-      await rpc('tools/call', { name: 'list_unmatched_tags', arguments: {} });
-      expect(vi.mocked(handleListUnmatchedTags)).toHaveBeenCalledOnce();
-    });
-
-    it('dispatches to handlePromoteConcept for name="promote_concept"', async () => {
-      await rpc('tools/call', { name: 'promote_concept', arguments: { pref_label: 'test', scheme: 'domains' } });
-      expect(vi.mocked(handlePromoteConcept)).toHaveBeenCalledOnce();
-    });
-
-    it('dispatches to handleSearchChunks for name="search_chunks"', async () => {
-      await rpc('tools/call', { name: 'search_chunks', arguments: { query: 'test' } });
-      expect(vi.mocked(handleSearchChunks)).toHaveBeenCalledOnce();
-    });
-
-    it('returns -32601 for an unknown tool name', async () => {
-      const res = await rpc('tools/call', { name: 'nonexistent_tool', arguments: {} });
-      const body = await parseRpc(res);
-      expect((body['error'] as Record<string, unknown>)?.['code']).toBe(-32601);
-    });
-
-    it('returns -32602 when params.name is missing', async () => {
-      const res = await rpc('tools/call', { arguments: {} });
-      const body = await parseRpc(res);
-      expect((body['error'] as Record<string, unknown>)?.['code']).toBe(-32602);
-    });
-
-    it('wraps tool result in JSON-RPC result envelope', async () => {
-      const res = await rpc('tools/call', { name: 'list_recent', arguments: {} });
-      const body = await parseRpc(res);
+  describe('delegates to handleMcpRequest after auth', () => {
+    it('returns valid JSON-RPC response for an authenticated request', async () => {
+      const res = await handler.fetch(
+        new Request('https://worker.example.com/mcp', {
+          method: 'POST',
+          headers: authHeaders(),
+          body: rpcBody('initialize'),
+        }),
+        MOCK_ENV,
+      );
+      const body = await res.json() as Record<string, unknown>;
       expect(body['jsonrpc']).toBe('2.0');
-      expect(body['result']).toEqual(MOCK_TOOL_RESULT);
-    });
-
-    it('passes arguments to handler (not undefined)', async () => {
-      await rpc('tools/call', { name: 'search_notes', arguments: { query: 'my query' } });
-      const call = vi.mocked(handleSearchNotes).mock.calls[0]!;
-      expect(call[0]).toEqual({ query: 'my query' });
-    });
-  });
-
-  describe('unknown method', () => {
-    it('returns -32601 for an unrecognised method', async () => {
-      const res = await rpc('ping');
-      const body = await parseRpc(res);
-      expect((body['error'] as Record<string, unknown>)?.['code']).toBe(-32601);
-    });
-  });
-
-  describe('response shape', () => {
-    it('success responses have Content-Type: application/json', async () => {
-      const res = await rpc('initialize');
-      expect(res.headers.get('Content-Type')).toContain('application/json');
-    });
-
-    it('success responses include CORS headers', async () => {
-      const res = await rpc('initialize');
-      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
-    });
-
-    it('error responses include jsonrpc, id, and error.code + message', async () => {
-      const res = await rpc('ping');
-      const body = await parseRpc(res);
-      expect(body['jsonrpc']).toBe('2.0');
-      expect(body['id']).toBe(1);
-      const err = body['error'] as Record<string, unknown>;
-      expect(typeof err['code']).toBe('number');
-      expect(typeof err['message']).toBe('string');
+      expect(body['result']).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Extract JSON-RPC dispatch logic from the monolithic `fetch()` handler into an exported `handleMcpRequest(request, env)` function — preparing the codebase for OAuthProvider integration (issue #5, sub-issue C)
- Add `isStaticTokenRequest()` to `mcp/src/auth.ts` using constant-time string comparison (replaces timing-vulnerable `!==` check)
- Split `tests/mcp-index.test.ts` into wrapper tests (auth/routing/CORS) and `tests/mcp-dispatch.test.ts` (JSON-RPC protocol/tool dispatch)

Zero behavioral change for existing callers. Pure refactor + security hardening.

Closes #59

## Test plan

- [x] `npx tsc --noEmit -p mcp/tsconfig.json` passes
- [x] `npx tsc --noEmit` passes (main project)
- [x] All 185 MCP unit tests pass (auth, config, embed, parser, tools, index, dispatch)
- [x] `isStaticTokenRequest` tested: matching token, wrong token, different-length token, missing header, non-Bearer scheme
- [x] Deployed to live Worker — 24 smoke tests pass
- [x] Static token callers see zero change

🤖 Generated with [Claude Code](https://claude.com/claude-code)