### PR TITLE
chore: add OAuth KV namespace + workers-oauth-provider dependency

### DIFF
--- a/mcp/src/types.ts
+++ b/mcp/src/types.ts
@@ -9,6 +9,7 @@ export interface Env {
   EMBED_MODEL: string;
   MATCH_THRESHOLD: string;
   MCP_SEARCH_THRESHOLD: string;
+  OAUTH_KV: KVNamespace;
 }
 
 // ── Note Types ──────────────────────────────────────────────────────────────

--- a/mcp/wrangler.toml
+++ b/mcp/wrangler.toml
@@ -8,6 +8,11 @@ CAPTURE_MODEL = "anthropic/claude-haiku-4-5"
 EMBED_MODEL = "openai/text-embedding-3-small"
 MATCH_THRESHOLD = "0.35"
 
+[[kv_namespaces]]
+binding = "OAUTH_KV"
+id = "11030833d3ce42c982434edef755ee2e"
+preview_id = "7626e22d14e94b2ea1e6bf40edb5d60d"
+
 # Secrets (set via: wrangler secret put <NAME> -c mcp/wrangler.toml):
 # MCP_API_KEY
 # SUPABASE_URL

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "contemplace",
       "version": "0.1.0",
       "dependencies": {
+        "@cloudflare/workers-oauth-provider": "^0.3.0",
         "@supabase/supabase-js": "^2",
         "openai": "^4"
       },
@@ -128,6 +129,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@cloudflare/workers-oauth-provider": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.3.0.tgz",
+      "integrity": "sha512-I39kyUzNQWxVTIQs56xbnnHSrOY5UjiGKVeYI2zY5h+LjUxqeiuOBTTlKEDUirRvnMmBg3yppA6pR8bYKBrTAA==",
+      "license": "MIT"
     },
     "node_modules/@cloudflare/workers-types": {
       "version": "4.20260307.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@cloudflare/workers-oauth-provider": "0.3.0",
     "@supabase/supabase-js": "^2",
     "openai": "^4"
   },


### PR DESCRIPTION
## Summary

- Install `@cloudflare/workers-oauth-provider@0.3.0` (pinned — library is actively evolving)
- Create `OAUTH_KV` KV namespace (production + preview) for OAuth token storage
- Add `OAUTH_KV: KVNamespace` to MCP Worker `Env` interface
- Nothing wired up — zero behavioral change

Infrastructure prep for Phase 2c OAuth 2.1 (#5, sub-issue #60).

## Test plan

- [x] `npx tsc --noEmit` passes (main project)
- [x] `npx tsc --noEmit -p mcp/tsconfig.json` passes (MCP project)
- [x] 185 MCP unit tests pass
- [x] 24 MCP smoke tests pass against live Worker
- [x] KV binding visible in deploy output
- [x] Existing behavior unchanged

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)