### PR TITLE
feat: secure OAuth consent page with CONSENT_SECRET

### DIFF
--- a/mcp/src/oauth.ts
+++ b/mcp/src/oauth.ts
@@ -1,4 +1,5 @@
 import type { AuthRequest, ClientInfo } from '@cloudflare/workers-oauth-provider';
+import { timingSafeEqual } from './auth';
 import type { Env } from './types';
 
 /** Single-user system — fixed user ID for all grants */
@@ -11,6 +12,7 @@ export const OWNER_USER_ID = 'owner';
 export function renderConsentPage(
   authRequest: AuthRequest,
   clientInfo: ClientInfo | null,
+  options?: { requireSecret?: boolean },
 ): string {
   const clientName = escapeHtml(clientInfo?.clientName ?? 'Unknown client');
   const redirectUri = escapeHtml(authRequest.redirectUri);
@@ -28,6 +30,8 @@ export function renderConsentPage(
     .client-name { font-weight: 600; }
     .redirect { font-family: monospace; font-size: 0.85rem; background: #e8e8e8; padding: 8px 12px; border-radius: 4px; word-break: break-all; margin: 12px 0; }
     .scope { color: #666; font-size: 0.9rem; margin-bottom: 20px; }
+    label { display: block; font-size: 0.9rem; margin-bottom: 4px; color: #333; }
+    input[type="password"] { width: 100%; padding: 8px 12px; border: 1px solid #ccc; border-radius: 4px; font-size: 1rem; margin-bottom: 16px; box-sizing: border-box; }
     button { background: #2563eb; color: white; border: none; padding: 12px 32px; border-radius: 6px; font-size: 1rem; cursor: pointer; }
     button:hover { background: #1d4ed8; }
     .note { font-size: 0.8rem; color: #888; margin-top: 24px; }
@@ -48,6 +52,8 @@ export function renderConsentPage(
     ${authRequest.codeChallenge ? `<input type="hidden" name="code_challenge" value="${escapeHtml(authRequest.codeChallenge)}">` : ''}
     ${authRequest.codeChallengeMethod ? `<input type="hidden" name="code_challenge_method" value="${escapeHtml(authRequest.codeChallengeMethod)}">` : ''}
     ${authRequest.resource ? `<input type="hidden" name="resource" value="${escapeHtml(typeof authRequest.resource === 'string' ? authRequest.resource : authRequest.resource.join(' '))}">` : ''}
+    ${options?.requireSecret ? `<label for="consent_secret">Passphrase</label>
+    <input type="password" id="consent_secret" name="consent_secret" required autocomplete="off">` : ''}
     <button type="submit">Approve</button>
   </form>
   <p class="note">Single-user system. If you are not the owner, close this page.</p>
@@ -74,11 +80,16 @@ export const AuthHandler: ExportedHandler<Env> = {
       return new Response('Internal Server Error', { status: 500 });
     }
 
+    const requireSecret = Boolean(env.CONSENT_SECRET);
+    if (!requireSecret) {
+      console.warn(JSON.stringify({ event: 'consent_no_secret', warning: 'CONSENT_SECRET not set — consent page is unprotected' }));
+    }
+
     if (request.method === 'GET') {
       try {
         const authRequest = await oauthHelpers.parseAuthRequest(request);
         const clientInfo = await oauthHelpers.lookupClient(authRequest.clientId);
-        const html = renderConsentPage(authRequest, clientInfo);
+        const html = renderConsentPage(authRequest, clientInfo, { requireSecret });
         return new Response(html, {
           status: 200,
           headers: { 'Content-Type': 'text/html; charset=utf-8' },
@@ -92,6 +103,17 @@ export const AuthHandler: ExportedHandler<Env> = {
     if (request.method === 'POST') {
       try {
         const formData = await request.formData();
+
+        if (requireSecret) {
+          const submitted = (formData.get('consent_secret') as string) ?? '';
+          if (!submitted || !timingSafeEqual(submitted, env.CONSENT_SECRET)) {
+            console.warn(JSON.stringify({ event: 'consent_secret_failed' }));
+            return new Response(renderDeniedPage(), {
+              status: 403,
+              headers: { 'Content-Type': 'text/html; charset=utf-8' },
+            });
+          }
+        }
 
         const authRequest: AuthRequest = {
           clientId: formData.get('client_id') as string ?? '',
@@ -122,6 +144,26 @@ export const AuthHandler: ExportedHandler<Env> = {
     return new Response('Method Not Allowed', { status: 405 });
   },
 };
+
+export function renderDeniedPage(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Denied — ContemPlace</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; max-width: 420px; margin: 60px auto; padding: 0 20px; color: #1a1a1a; background: #fafafa; }
+    h1 { font-size: 1.3rem; color: #dc2626; }
+    a { color: #2563eb; }
+  </style>
+</head>
+<body>
+  <h1>Authorization denied</h1>
+  <p>The passphrase was incorrect. <a href="javascript:history.back()">Go back</a> and try again.</p>
+</body>
+</html>`;
+}
 
 function escapeHtml(str: string): string {
   return str

--- a/mcp/src/types.ts
+++ b/mcp/src/types.ts
@@ -4,6 +4,7 @@ import type { OAuthHelpers } from '@cloudflare/workers-oauth-provider';
 
 export interface Env {
   MCP_API_KEY: string;
+  CONSENT_SECRET: string;
   SUPABASE_URL: string;
   SUPABASE_SERVICE_ROLE_KEY: string;
   OPENROUTER_API_KEY: string;

--- a/mcp/wrangler.toml
+++ b/mcp/wrangler.toml
@@ -15,6 +15,7 @@ preview_id = "7626e22d14e94b2ea1e6bf40edb5d60d"
 
 # Secrets (set via: wrangler secret put <NAME> -c mcp/wrangler.toml):
 # MCP_API_KEY
+# CONSENT_SECRET          — protects the OAuth consent page; generate with: openssl rand -hex 16
 # SUPABASE_URL
 # SUPABASE_SERVICE_ROLE_KEY
 # OPENROUTER_API_KEY

--- a/tests/mcp-index.test.ts
+++ b/tests/mcp-index.test.ts
@@ -58,6 +58,7 @@ const MOCK_ENV = {
   EMBED_MODEL: 'openai/text-embedding-3-small',
   MATCH_THRESHOLD: '0.60',
   OAUTH_KV: {},
+  CONSENT_SECRET: 'test-consent-secret',
 };
 
 const MOCK_CTX = {

--- a/tests/mcp-oauth.test.ts
+++ b/tests/mcp-oauth.test.ts
@@ -3,11 +3,16 @@
  * Pure unit tests — no network, no KV.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderConsentPage, AuthHandler, OWNER_USER_ID } from '../mcp/src/oauth';
+import { renderConsentPage, renderDeniedPage, AuthHandler, OWNER_USER_ID } from '../mcp/src/oauth';
 import type { AuthRequest, ClientInfo } from '@cloudflare/workers-oauth-provider';
 
 // ── Mock OAuthProvider (module-level, prevents cloudflare:workers import) ─────
 vi.mock('@cloudflare/workers-oauth-provider', () => ({}));
+
+// ── Mock timingSafeEqual (module-level) ──────────────────────────────────────
+vi.mock('../mcp/src/auth', () => ({
+  timingSafeEqual: (a: string, b: string) => a === b,
+}));
 
 // ── Test helpers ─────────────────────────────────────────────────────────────
 
@@ -34,9 +39,12 @@ function makeClientInfo(overrides: Partial<ClientInfo> = {}): ClientInfo {
   };
 }
 
+const TEST_CONSENT_SECRET = 'test-consent-secret-value';
+
 function makeEnv(overrides: Record<string, unknown> = {}) {
   return {
     MCP_API_KEY: 'test-key',
+    CONSENT_SECRET: TEST_CONSENT_SECRET,
     SUPABASE_URL: 'https://example.supabase.co',
     SUPABASE_SERVICE_ROLE_KEY: 'service-key',
     OPENROUTER_API_KEY: 'or-key',
@@ -122,6 +130,35 @@ describe('renderConsentPage', () => {
     );
     expect(html).toContain('name="resource"');
     expect(html).toContain('value="https://mcp.example.com"');
+  });
+
+  it('omits passphrase field when requireSecret is false', () => {
+    const html = renderConsentPage(makeAuthRequest(), makeClientInfo(), { requireSecret: false });
+    expect(html).not.toContain('name="consent_secret"');
+    expect(html).not.toContain('Passphrase');
+  });
+
+  it('omits passphrase field when options not provided', () => {
+    const html = renderConsentPage(makeAuthRequest(), makeClientInfo());
+    expect(html).not.toContain('name="consent_secret"');
+  });
+
+  it('includes passphrase field when requireSecret is true', () => {
+    const html = renderConsentPage(makeAuthRequest(), makeClientInfo(), { requireSecret: true });
+    expect(html).toContain('name="consent_secret"');
+    expect(html).toContain('type="password"');
+    expect(html).toContain('Passphrase');
+  });
+});
+
+// ── renderDeniedPage tests ──────────────────────────────────────────────────
+
+describe('renderDeniedPage', () => {
+  it('renders valid HTML with denial message', () => {
+    const html = renderDeniedPage();
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('Authorization denied');
+    expect(html).toContain('passphrase was incorrect');
   });
 });
 
@@ -214,8 +251,8 @@ describe('AuthHandler', () => {
   });
 
   describe('POST /authorize — consent submission', () => {
-    it('completes authorization and redirects', async () => {
-      const body = new URLSearchParams({
+    function postBody(extra: Record<string, string> = {}) {
+      return new URLSearchParams({
         client_id: 'test-client-id',
         redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
         state: 'random-state',
@@ -223,13 +260,17 @@ describe('AuthHandler', () => {
         response_type: 'code',
         code_challenge: 'abc123',
         code_challenge_method: 'S256',
+        consent_secret: TEST_CONSENT_SECRET,
+        ...extra,
       });
+    }
 
+    it('completes authorization and redirects with correct secret', async () => {
       const res = await AuthHandler.fetch!(
         new Request('https://worker.example.com/authorize', {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: body.toString(),
+          body: postBody().toString(),
         }),
         envWithHelpers() as never,
         {} as ExecutionContext,
@@ -240,19 +281,11 @@ describe('AuthHandler', () => {
     });
 
     it('calls completeAuthorization with owner user ID', async () => {
-      const body = new URLSearchParams({
-        client_id: 'test-client-id',
-        redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
-        state: 'random-state',
-        scope: 'mcp',
-        response_type: 'code',
-      });
-
       await AuthHandler.fetch!(
         new Request('https://worker.example.com/authorize', {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: body.toString(),
+          body: postBody().toString(),
         }),
         envWithHelpers() as never,
         {} as ExecutionContext,
@@ -267,14 +300,42 @@ describe('AuthHandler', () => {
 
     it('returns 400 when completeAuthorization throws', async () => {
       mockCompleteAuthorization.mockRejectedValue(new Error('bad grant'));
+      const res = await AuthHandler.fetch!(
+        new Request('https://worker.example.com/authorize', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: postBody().toString(),
+        }),
+        envWithHelpers() as never,
+        {} as ExecutionContext,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 403 when consent_secret is wrong', async () => {
+      const res = await AuthHandler.fetch!(
+        new Request('https://worker.example.com/authorize', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: postBody({ consent_secret: 'wrong-value' }).toString(),
+        }),
+        envWithHelpers() as never,
+        {} as ExecutionContext,
+      );
+      expect(res.status).toBe(403);
+      const html = await res.text();
+      expect(html).toContain('Authorization denied');
+      expect(mockCompleteAuthorization).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when consent_secret is missing', async () => {
       const body = new URLSearchParams({
-        client_id: 'test',
-        redirect_uri: 'https://example.com',
-        state: 's',
+        client_id: 'test-client-id',
+        redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+        state: 'random-state',
         scope: 'mcp',
         response_type: 'code',
       });
-
       const res = await AuthHandler.fetch!(
         new Request('https://worker.example.com/authorize', {
           method: 'POST',
@@ -284,7 +345,45 @@ describe('AuthHandler', () => {
         envWithHelpers() as never,
         {} as ExecutionContext,
       );
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(403);
+      expect(mockCompleteAuthorization).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when consent_secret is empty string', async () => {
+      const res = await AuthHandler.fetch!(
+        new Request('https://worker.example.com/authorize', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: postBody({ consent_secret: '' }).toString(),
+        }),
+        envWithHelpers() as never,
+        {} as ExecutionContext,
+      );
+      expect(res.status).toBe(403);
+      expect(mockCompleteAuthorization).not.toHaveBeenCalled();
+    });
+
+    it('allows POST without secret when CONSENT_SECRET is not set (graceful degradation)', async () => {
+      const body = new URLSearchParams({
+        client_id: 'test-client-id',
+        redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+        state: 'random-state',
+        scope: 'mcp',
+        response_type: 'code',
+      });
+      const env = envWithHelpers();
+      (env as Record<string, unknown>).CONSENT_SECRET = '';
+      const res = await AuthHandler.fetch!(
+        new Request('https://worker.example.com/authorize', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: body.toString(),
+        }),
+        env as never,
+        {} as ExecutionContext,
+      );
+      expect(res.status).toBe(302);
+      expect(mockCompleteAuthorization).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds a `CONSENT_SECRET` passphrase field to the OAuth consent page, validated via constant-time comparison before `completeAuthorization()` is called
- An unauthenticated user can no longer complete the OAuth flow — the consent page (`/authorize`) is the chokepoint, and it now requires the secret
- Static `MCP_API_KEY` callers are completely unaffected (different code path via `resolveExternalToken`)
- Graceful degradation: if `CONSENT_SECRET` is not set, the page works as before (open gate) with a console warning

Closes #66

## Design decisions

| Decision | Choice |
|---|---|
| Check on GET or POST? | **POST only** — GET is harmless (shows form). Secret in query params would leak in browser history. |
| Per-session cookie? | **No** — consent happens ~once per client per 30-day refresh token lifetime. Not worth the cookie-signing complexity. |
| Protect `/register` (DCR)? | **No** — registered clients are inert without consent page access. |
| Graceful degradation? | **Yes** — empty `CONSENT_SECRET` = open gate + console warning. Deploy code before setting secret. |

## Files changed

- `mcp/src/types.ts` — `CONSENT_SECRET` added to `Env`
- `mcp/src/oauth.ts` — passphrase field in consent form, secret validation in POST handler, denial page renderer
- `mcp/wrangler.toml` — documented new secret
- `tests/mcp-oauth.test.ts` — 8 new tests (passphrase field rendering, wrong/missing/empty secret rejection, graceful degradation, denial page)
- `tests/mcp-index.test.ts` — added `CONSENT_SECRET` to mock env

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] 27 OAuth unit tests pass (was 19, added 8)
- [x] 15 index unit tests pass
- [x] 176 remaining MCP unit tests pass (no regressions)
- [x] MCP Worker deployed, `CONSENT_SECRET` set via `wrangler secret put`
- [x] Static token path verified (initialize call succeeds)
- [x] 27 MCP smoke tests pass against live Worker
- [ ] Manual: complete OAuth flow with Claude.ai web connector using the passphrase

🤖 Generated with [Claude Code](https://claude.com/claude-code)