### PR TITLE
feat: reframe capture pipeline for fragment-first philosophy

### DIFF
--- a/docs/capture-agent.md
+++ b/docs/capture-agent.md
@@ -1,24 +1,24 @@
 # Capture agent
 
-The capture agent is an LLM that turns raw user input into a structured note. It runs once per message, produces 7 fields in a single pass, and never asks the user for clarification.
+The capture agent is an LLM that turns raw user input into a structured fragment. It runs once per message, produces 7 fields in a single pass, and never asks the user for clarification.
 
 > **Note (2026-03-13):** `type`, `intent`, and `modality` were removed from the capture pipeline (#110, decision in #104). The classification complexity didn't justify the marginal retrieval value. The fields below — title, body, tags, entities, links, corrections, source_ref — are the capture output. Existing notes may still have type/intent/modality values from before the change.
 
-## What is an atomic note?
+## What goes in?
 
-An atomic note captures one idea in the user's own voice — something that earns a single claim as its title without needing "and" to connect two separate points.
+The system captures idea fragments — whatever the user sends, in their own voice. A fragment can be a focused single thought, a rough observation, a question, a quote, a reflection. No pressure to be atomic or complete. The capture pipeline structures each fragment (title, body, tags, entities, links) and preserves the user's exact words in `raw_input`.
 
-**Properties:**
-- **One central claim or question.** If the note needs two titles to be honest, it's two notes.
+Fragments with these properties produce the best immediate results from the capture pipeline:
+- **One central claim or question.** A single claim title covers the fragment honestly.
 - **Self-contained.** A reader gets the point without chasing dependencies.
-- **Voice-preserving.** Reads like the user talking — their words, their phrasing. Mid-thought starts are fine. Throat-clearing is not.
-- **Complete but not padded.** Enough to land the idea, no more. A 20-word note that makes its point beats a 100-word note that circles it.
+- **Voice-preserving.** Reads like the user talking — their words, their phrasing. Mid-thought starts are fine.
+- **Complete but not padded.** Enough to land the idea, no more.
 
-**What atomic doesn't mean:** Not "short" (a complex idea with examples might be 200 words). Not "simple" (nuanced positions are fine). Not "permanent" (notes may grow through accretion — atomicity governs the capture event, not the note's final form).
+These are ideals, not requirements. Every fragment is captured faithfully regardless of how close it is to these properties. The value of a fragment doesn't come only from its individual structure — it also comes from how it connects to and accumulates with other fragments over time. The synthesis layer (planned) builds higher-order structures from accumulated fragments.
 
 ### Title model
 
-The title states the note's claim or poses its question. It never merely labels a topic.
+The title states the fragment's claim or poses its question. It never merely labels a topic.
 
 - **Claim title** (default): "Espresso workflow needs a dedicated grinder"
 - **Question title** (for exploratory input): "Is SKOS overkill for a personal tag vocabulary?"
@@ -29,27 +29,29 @@ The claim must be the user's claim, derivable from their words — never editori
 ### Descriptive range (not prescriptive)
 
 - Sweet spot: 20–150 words in the body, 1–4 sentences
-- Below 20 words: fragment — captured but thin
-- Above 300 words: likely multi-idea — captured with soft warning
+- Below 20 words: thin but captured — may gain value through links and accumulation
+- Above 300 words: likely contains multiple ideas — the capture pipeline picks one for the title, which means the others get weaker structuring
 
-These are descriptions of where good atomic notes tend to land, not targets. Word count is a weak proxy for idea count. The real test is the title: if a single claim title covers the note honestly, it's atomic regardless of length.
+These are descriptions of where focused fragments tend to land, not targets. Word count is a weak proxy. The real test is the title: if a single claim title covers the fragment honestly, the pipeline will produce good structure regardless of length.
 
-### Non-atomic input
+### Multi-fragment input
 
-The system captures everything faithfully — it never rejects input. Non-atomic input (brain dumps, multi-topic streams, long lists) produces degraded structured outputs: the title can only name one idea, tags blur across topics, links become ambiguous. The user is warned softly but the note is always stored with `raw_input` preserved.
+The system captures everything faithfully — it never rejects input. When input contains multiple ideas, the structured output is degraded: the title can only name one idea, tags blur across topics, links become ambiguous. The fragment is still stored with `raw_input` preserved.
 
-Detection heuristics (2+ signals trigger a soft nudge):
+Detection heuristics (used as quality signals for the capture LLM, not as user-facing warnings):
 
 | Signal | Threshold |
 |---|---|
-| Word count < 10 | Fragment flag |
-| Word count > 300 | Multi-idea flag |
+| Word count < 10 | Thin fragment |
+| Word count > 300 | Likely multi-idea |
 | Enumerated list | 3+ items |
 | Multiple paragraphs | 3+ |
 | Tag spread across 3+ domains | Scatter signal |
 | Title requires "and" between unrelated clauses | Multi-idea signal |
 
-For full research basis, see [#108](https://github.com/freegyes/project-ContemPlace/issues/108).
+These heuristics help the capture LLM assess how to structure its output. The implications for user-facing behavior (whether/how to surface these signals) need design work — see #116.
+
+For the original research basis, see [#108](https://github.com/freegyes/project-ContemPlace/issues/108).
 
 ## Entity extraction
 
@@ -134,7 +136,7 @@ The parser is covered by unit tests (`tests/parser.test.ts`) that run locally wi
 
 ## Tuning the capture voice
 
-The stylistic rules live in the `capture_profiles` table, not in code. To change how titles are phrased, how bodies read, or what examples the LLM sees:
+The stylistic rules live in the `capture_profiles` table, not in code. To change how titles are phrased, how the body reads, or what examples the LLM sees:
 
 ```sql
 UPDATE capture_profiles
@@ -144,4 +146,4 @@ WHERE name = 'default';
 
 No redeployment needed. The next capture will fetch the updated voice.
 
-The structural contract (JSON schema, enum values, extraction rules) lives in `SYSTEM_FRAME` in `src/capture.ts`. Changing that requires a code deployment. This split is intentional — structural changes are rare and need testing; stylistic tuning should be instant.
+The structural contract (JSON schema, enum values, extraction rules) lives in `SYSTEM_FRAME` in `mcp/src/capture.ts`. Changing that requires a code deployment. This split is intentional — structural changes are rare and need testing; stylistic tuning should be instant.

--- a/mcp/src/capture.ts
+++ b/mcp/src/capture.ts
@@ -5,7 +5,7 @@ import type { CaptureResult, CaptureLink, MatchedNote, CaptureLinkType, Entity }
 // ── System frame: structural contract between LLM and parser ──────────────────
 // This part stays in code. It defines the JSON schema, field enums,
 // entity/link rules — everything the parser depends on. Users don't touch it.
-const SYSTEM_FRAME = `You are a knowledge capture agent. Transform raw input into a single structured note and identify relationships to existing notes.
+const SYSTEM_FRAME = `You are a knowledge capture agent. Structure the user's raw input as a single fragment and identify relationships to existing notes.
 
 ## Voice recognition correction
 
@@ -16,7 +16,7 @@ Input may come from voice dictation or quick typing. Before anything else:
 
 ## Output fields
 
-**Tags**: 2–7 lowercase kebab-case strings (e.g., \`laser-cutting\`, \`sound-art\`, \`experience-design\`). No \`#\` prefix, no spaces — use hyphens for multi-word tags. Include the specific subject of the note as a tag (e.g., \`cimbalom\`, not just \`percussion\`). Use remaining slots for broader categories.
+**Tags**: 2–7 lowercase kebab-case strings (e.g., \`laser-cutting\`, \`sound-art\`, \`experience-design\`). No \`#\` prefix, no spaces — use hyphens for multi-word tags. Include the specific subject of the fragment as a tag (e.g., \`cimbalom\`, not just \`percussion\`). Use remaining slots for broader categories.
 
 **source_ref**: URL if the user included one, otherwise null.
 
@@ -36,12 +36,12 @@ Types: \`extends | contradicts | supports | is-example-of | duplicate-of\`
 - \`contradicts\` — challenges or is in tension with it
 - \`supports\` — provides evidence, reinforces, or is a parallel/sibling idea toward the same goal
 - \`is-example-of\` — a concrete instance of the other note's concept
-- \`duplicate-of\` — the new note covers substantially the same content as the related note. Test: if you would give the new note the same or nearly identical title as the related note, it is a duplicate. Use \`duplicate-of\`, not \`supports\`. Still create the note — deduplication is a gardening concern, not a capture concern.
+- \`duplicate-of\` — the new fragment covers substantially the same content as the related note. Test: if you would give the new fragment the same or nearly identical title as the related note, it is a duplicate. Use \`duplicate-of\`, not \`supports\`. Still create the note — deduplication is a gardening concern, not a capture concern.
 Prefer more links over fewer. It is fine to link to zero notes.
 
-If the input is too short to form a full note, do your best. Do not ask for clarification.
+If the input is very short, do your best. Do not ask for clarification.
 
-**Body rule**: if the input contains questions, preserve them as questions in the body. Do not answer them, synthesize related notes into an answer, or reframe them as statements. The note captures what the user said, not what the system thinks the answer is. Related notes are provided for linking context only — never fold their content into the body.
+**Body rule**: if the input contains questions, preserve them as questions in the body. Do not answer them, synthesize related notes into an answer, or reframe them as statements. The body captures what the user said, not what the system thinks the answer is. Related notes are provided for linking context only — never fold their content into the body.
 
 Return valid JSON only. No text outside the JSON object.
 {

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -75,7 +75,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'capture_note',
-    description: 'Capture a thought as a permanent note. Required parameter: raw_input (the user\'s verbatim words). The server embeds, finds related notes, and automatically generates a structured note (title, body, tags, entities, links). Do not pre-structure, summarize, or clean up the input. Voice dictation errors are expected and corrected server-side. Side effect: creates a persistent note.',
+    description: 'Capture an idea fragment. Required parameter: raw_input (the user\'s verbatim words). The server embeds, finds related notes, and structures the fragment (title, body, tags, entities, links). Do not pre-structure, summarize, or clean up the input. Voice dictation errors are expected and corrected server-side. Side effect: creates a persistent fragment.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ export default {
     // ── 6. /start command ────────────────────────────────────────────────────
     if (text.trim() === '/start') {
       ctx.waitUntil(
-        sendTelegramMessage(config, chatId, 'ContemPlace is running. Send me any text to capture it as a note.')
+        sendTelegramMessage(config, chatId, 'ContemPlace is running. Send me any text to capture it.')
       );
       return new Response('ok', { status: 200 });
     }
@@ -106,7 +106,7 @@ async function processCapture(
     await sendTelegramMessage(
       config,
       chatId,
-      'Something went wrong capturing your note. Check the Worker logs for details.',
+      'Something went wrong capturing that. Check the Worker logs for details.',
     );
   }
 }

--- a/supabase/migrations/20260314000000_v3_schema.sql
+++ b/supabase/migrations/20260314000000_v3_schema.sql
@@ -207,7 +207,7 @@ CREATE TRIGGER capture_profiles_updated_at
 -- Seed the default capture voice (updated version from 20260312000001)
 INSERT INTO capture_profiles (name, capture_voice) VALUES ('default', '## Your capture style
 
-**Title**: A claim or insight when one is present. A good title lets you scan a list and know what the note says without opening it. If the input doesn''t contain a claim, use a descriptive phrase. Never a topic label.
+**Title**: A claim or insight when one is present. A good title lets you scan a list and know what the fragment says without opening it. If the input doesn''t contain a claim, use a descriptive phrase. Never a topic label.
 
 **Body**: Use the user''s own words. Every sentence must be traceable to the input. Enough to land the idea, no more — shorter is better than padded, but completeness beats brevity when the idea requires it. Never compress, never add inferred meanings, never add a concluding sentence that summarizes what the user''s words already showed. Do not synthesize or interpret. The body is transcription, not synthesis.');
 


### PR DESCRIPTION
## Summary

- **SYSTEM_FRAME** (`mcp/src/capture.ts`): "structured note" → "structured fragment", "subject of the note" → "subject of the fragment", "new note covers" → "new fragment covers", "too short to form a full note" → "very short" (drops implicit quality bar), "The note captures" → "The body captures"
- **`capture_note` tool description** (`mcp/src/tools.ts`): "permanent note" → "idea fragment", "structured note" → "structures the fragment", "persistent note" → "persistent fragment"
- **Capture voice seed** (`supabase/migrations/`): "what the note says" → "what the fragment says"
- **Telegram messages** (`src/index.ts`): `/start` drops "as a note", error message drops "your note"
- **`docs/capture-agent.md`**: "structured note" → "structured fragment", fixes stale `src/capture.ts` path → `mcp/src/capture.ts`

No behavioral changes — text-only reframe. Detection heuristics remain in docs only (not in the prompt); adding them to the prompt is #109's scope.

refs #119

## Deployment

1. **UPDATE live `capture_profiles` DB row** before deploying code:
   ```sql
   UPDATE capture_profiles
   SET capture_voice = '## Your capture style

   **Title**: A claim or insight when one is present. A good title lets you scan a list and know what the fragment says without opening it. If the input doesn''t contain a claim, use a descriptive phrase. Never a topic label.

   **Body**: Use the user''s own words. Every sentence must be traceable to the input. Enough to land the idea, no more — shorter is better than padded, but completeness beats brevity when the idea requires it. Never compress, never add inferred meanings, never add a concluding sentence that summarizes what the user''s words already showed. Do not synthesize or interpret. The body is transcription, not synthesis.'
   WHERE name = 'default';
   ```
2. Deploy MCP Worker (`wrangler deploy -c mcp/wrangler.toml`)
3. Deploy Telegram Worker (`wrangler deploy`)
4. Run smoke + semantic tests

## Test plan

- [x] `tsc --noEmit` — both Workers pass
- [x] Parser unit tests (13 tests) — pass
- [x] MCP tools unit tests (88 tests) — pass
- [x] MCP dispatch unit tests (27 tests) — pass
- [ ] Deploy and run smoke tests
- [ ] Deploy and run semantic test suite
- [ ] Send a test Telegram message — verify reply renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)