### PR TITLE
feat: Telegram /undo command

### DIFF
--- a/mcp/src/db.ts
+++ b/mcp/src/db.ts
@@ -262,6 +262,32 @@ export async function searchNotes(
   return (data as MatchedNote[]) ?? [];
 }
 
+// ── Undo functions ────────────────────────────────────────────────────────
+
+export interface MostRecentNote {
+  id: string;
+  title: string;
+  created_at: string;
+}
+
+// Fetch the most recent active note from a specific source.
+export async function fetchMostRecentBySource(
+  db: SupabaseClient,
+  source: string,
+): Promise<MostRecentNote | null> {
+  const { data, error } = await db
+    .from('notes')
+    .select('id, title, created_at')
+    .eq('source', source)
+    .is('archived_at', null)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (error || !data) return null;
+  return data as MostRecentNote;
+}
+
 // ── Archive functions ──────────────────────────────────────────────────────
 
 export interface NoteForArchive {

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -7,8 +7,8 @@ import { createOpenAIClient } from './embed';
 import { TOOL_DEFINITIONS, handleSearchNotes, handleGetNote, handleListRecent, handleGetRelated, handleCaptureNote, handleArchiveNote } from './tools';
 import { runCapturePipeline } from './pipeline';
 import { AuthHandler } from './oauth';
-import type { Env } from './types';
-import type { ServiceCaptureResult } from './types';
+import type { Env, ServiceCaptureResult, UndoResult } from './types';
+import { fetchMostRecentBySource, hardDeleteNote } from './db';
 
 // ── JSON-RPC helpers ─────────────────────────────────────────────────────────
 
@@ -166,6 +166,27 @@ export class CaptureService extends WorkerEntrypoint<Env> {
     const db = createClient(config.supabaseUrl, config.supabaseServiceRoleKey);
     const openai = createOpenAIClient(config);
     return runCapturePipeline(rawInput, source, db, openai, config);
+  }
+
+  async undoLatest(): Promise<UndoResult> {
+    const config = loadConfig(this.env);
+    const db = createClient(config.supabaseUrl, config.supabaseServiceRoleKey);
+
+    const note = await fetchMostRecentBySource(db, 'telegram');
+    if (!note) {
+      return { action: 'none' };
+    }
+
+    const ageMs = Date.now() - new Date(note.created_at).getTime();
+    const windowMs = config.hardDeleteWindowMinutes * 60 * 1000;
+
+    if (ageMs >= windowMs) {
+      return { action: 'grace_period_passed', title: note.title, id: note.id };
+    }
+
+    await hardDeleteNote(db, note.id);
+    console.log(JSON.stringify({ event: 'undo_hard_deleted', id: note.id, title: note.title }));
+    return { action: 'deleted', title: note.title, id: note.id };
   }
 }
 

--- a/mcp/src/types.ts
+++ b/mcp/src/types.ts
@@ -83,6 +83,15 @@ export interface LinkWithTitle {
   direction: 'outbound' | 'inbound';
 }
 
+// ── Undo result ─────────────────────────────────────────────────────────────
+// Returned by CaptureService.undoLatest() — safe for structured cloning across Service Bindings.
+
+export interface UndoResult {
+  action: 'deleted' | 'grace_period_passed' | 'none';
+  title?: string;
+  id?: string;
+}
+
 // ── Service Binding result ──────────────────────────────────────────────────
 // Rich result returned by CaptureService.capture() — designed for all gateways.
 // All fields are strings, arrays, or null — safe for structured cloning across Service Bindings.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { Env, TelegramUpdate, ServiceCaptureResult } from './types';
+import type { Env, TelegramUpdate, ServiceCaptureResult, UndoResult } from './types';
 import { loadConfig } from './config';
 import { sendTelegramMessage, sendTypingAction } from './telegram';
 import { createSupabaseClient, tryClaimUpdate } from './db';
@@ -61,6 +61,12 @@ export default {
       return new Response('ok', { status: 200 });
     }
 
+    // ── 6b. /undo command ──────────────────────────────────────────────────
+    if (text.trim() === '/undo') {
+      ctx.waitUntil(processUndo(env, config, chatId));
+      return new Response('ok', { status: 200 });
+    }
+
     // ── 7. Dedup check ───────────────────────────────────────────────────────
     const db = createSupabaseClient(config);
     const isNew = await tryClaimUpdate(db, update.update_id);
@@ -111,6 +117,39 @@ async function processCapture(
   }
 }
 
+async function processUndo(
+  env: Env,
+  config: { telegramBotToken: string; telegramWebhookSecret: string; allowedChatIds: number[]; supabaseUrl: string; supabaseServiceRoleKey: string },
+  chatId: number,
+): Promise<void> {
+  try {
+    const result: UndoResult = await env.CAPTURE_SERVICE.undoLatest();
+
+    let reply: string;
+    switch (result.action) {
+      case 'deleted':
+        reply = `Undone: <b>${escapeHtml(result.title!)}</b>`;
+        break;
+      case 'grace_period_passed':
+        reply = 'The grace period has passed. To archive a note, use an MCP session.';
+        break;
+      case 'none':
+        reply = 'Nothing to undo — no recent Telegram captures.';
+        break;
+    }
+
+    await sendTelegramMessage(config, chatId, reply, 'HTML');
+  } catch (err: unknown) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.error(JSON.stringify({ event: 'undo_error', error: errorMessage, chatId }));
+    await sendTelegramMessage(config, chatId, 'Something went wrong with undo. Try again.');
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 // ── Visual indicators for Telegram reply ─────────────────────────────────────
 // Emojis give each classification a consistent visual anchor so the user can
 // spot behavioral patterns at a glance without reading every label.
@@ -119,7 +158,7 @@ const LINK_EMOJI: Record<string, string> = {
   contradicts: '⚡', related: '🔗',
 };
 function formatTelegramReply(result: ServiceCaptureResult): string {
-  const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const esc = escapeHtml;
   const sep = '──────────────────────';
 
   // Title and body are prominent — everything else is italic metadata

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,8 +3,15 @@
 // CaptureService stub for Service Binding typing.
 // The actual implementation lives in mcp/src/index.ts (WorkerEntrypoint).
 // At runtime, Cloudflare resolves this via the [[services]] binding in wrangler.toml.
+export interface UndoResult {
+  action: 'deleted' | 'grace_period_passed' | 'none';
+  title?: string;
+  id?: string;
+}
+
 export interface CaptureServiceStub {
   capture(rawInput: string, source: string): Promise<ServiceCaptureResult>;
+  undoLatest(): Promise<UndoResult>;
 }
 
 export interface Env {

--- a/tests/undo.test.ts
+++ b/tests/undo.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for the /undo flow:
+ * - fetchMostRecentBySource (DB helper)
+ * - CaptureService.undoLatest() logic (grace-window hard delete or refuse)
+ *
+ * Tests mock the DB layer — no network.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Config } from '../mcp/src/config';
+import type { UndoResult } from '../mcp/src/types';
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('../mcp/src/db', () => ({
+  fetchMostRecentBySource: vi.fn().mockResolvedValue(null),
+  hardDeleteNote: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { fetchMostRecentBySource, hardDeleteNote } from '../mcp/src/db';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const MOCK_CONFIG: Config = {
+  mcpApiKey: 'test-key',
+  openrouterApiKey: 'or-key',
+  supabaseUrl: 'https://example.supabase.co',
+  supabaseServiceRoleKey: 'service-key',
+  captureModel: 'anthropic/claude-haiku-4-5',
+  embedModel: 'openai/text-embedding-3-small',
+  matchThreshold: 0.60,
+  searchThreshold: 0.35,
+  hardDeleteWindowMinutes: 11,
+};
+
+const VALID_UUID = 'aaaaaaaa-0000-0000-0000-000000000001';
+
+function minutesAgo(n: number): string {
+  return new Date(Date.now() - n * 60 * 1000).toISOString();
+}
+
+/**
+ * Simulate the undoLatest() logic without instantiating the full WorkerEntrypoint.
+ * This mirrors the implementation in CaptureService.undoLatest().
+ */
+async function undoLatest(db: SupabaseClient, config: Config): Promise<UndoResult> {
+  const note = await fetchMostRecentBySource(db, 'telegram');
+  if (!note) {
+    return { action: 'none' };
+  }
+
+  const ageMs = Date.now() - new Date(note.created_at).getTime();
+  const windowMs = config.hardDeleteWindowMinutes * 60 * 1000;
+
+  if (ageMs >= windowMs) {
+    return { action: 'grace_period_passed', title: note.title, id: note.id };
+  }
+
+  await hardDeleteNote(db, note.id);
+  return { action: 'deleted', title: note.title, id: note.id };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+const mockDb = {} as unknown as SupabaseClient;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('undoLatest', () => {
+  it('returns none when no active Telegram notes exist', async () => {
+    vi.mocked(fetchMostRecentBySource).mockResolvedValueOnce(null);
+    const r = await undoLatest(mockDb, MOCK_CONFIG);
+    expect(r.action).toBe('none');
+    expect(r.title).toBeUndefined();
+    expect(vi.mocked(hardDeleteNote)).not.toHaveBeenCalled();
+  });
+
+  it('hard-deletes a note within the grace window', async () => {
+    vi.mocked(fetchMostRecentBySource).mockResolvedValueOnce({
+      id: VALID_UUID,
+      title: 'Recent Note',
+      created_at: minutesAgo(3),
+    });
+    const r = await undoLatest(mockDb, MOCK_CONFIG);
+    expect(r.action).toBe('deleted');
+    expect(r.title).toBe('Recent Note');
+    expect(r.id).toBe(VALID_UUID);
+    expect(vi.mocked(hardDeleteNote)).toHaveBeenCalledWith(mockDb, VALID_UUID);
+  });
+
+  it('refuses when the note is beyond the grace window', async () => {
+    vi.mocked(fetchMostRecentBySource).mockResolvedValueOnce({
+      id: VALID_UUID,
+      title: 'Old Note',
+      created_at: minutesAgo(15),
+    });
+    const r = await undoLatest(mockDb, MOCK_CONFIG);
+    expect(r.action).toBe('grace_period_passed');
+    expect(r.title).toBe('Old Note');
+    expect(r.id).toBe(VALID_UUID);
+    expect(vi.mocked(hardDeleteNote)).not.toHaveBeenCalled();
+  });
+
+  it('refuses at the exact grace window boundary', async () => {
+    vi.mocked(fetchMostRecentBySource).mockResolvedValueOnce({
+      id: VALID_UUID,
+      title: 'Boundary Note',
+      created_at: minutesAgo(11),
+    });
+    const r = await undoLatest(mockDb, MOCK_CONFIG);
+    expect(r.action).toBe('grace_period_passed');
+    expect(vi.mocked(hardDeleteNote)).not.toHaveBeenCalled();
+  });
+
+  it('hard-deletes a note just inside the grace window', async () => {
+    vi.mocked(fetchMostRecentBySource).mockResolvedValueOnce({
+      id: VALID_UUID,
+      title: 'Just Inside',
+      created_at: minutesAgo(10),
+    });
+    const r = await undoLatest(mockDb, MOCK_CONFIG);
+    expect(r.action).toBe('deleted');
+    expect(vi.mocked(hardDeleteNote)).toHaveBeenCalledOnce();
+  });
+
+  it('respects a custom grace window', async () => {
+    const shortWindow = { ...MOCK_CONFIG, hardDeleteWindowMinutes: 3 };
+    vi.mocked(fetchMostRecentBySource).mockResolvedValueOnce({
+      id: VALID_UUID,
+      title: 'Custom Window',
+      created_at: minutesAgo(5),
+    });
+    const r = await undoLatest(mockDb, shortWindow);
+    expect(r.action).toBe('grace_period_passed');
+    expect(vi.mocked(hardDeleteNote)).not.toHaveBeenCalled();
+  });
+
+  it('passes source "telegram" to fetchMostRecentBySource', async () => {
+    vi.mocked(fetchMostRecentBySource).mockResolvedValueOnce(null);
+    await undoLatest(mockDb, MOCK_CONFIG);
+    expect(vi.mocked(fetchMostRecentBySource)).toHaveBeenCalledWith(mockDb, 'telegram');
+  });
+
+  it('propagates DB read errors', async () => {
+    vi.mocked(fetchMostRecentBySource).mockRejectedValueOnce(new Error('DB read error'));
+    await expect(undoLatest(mockDb, MOCK_CONFIG)).rejects.toThrow('DB read error');
+  });
+
+  it('propagates DB write errors', async () => {
+    vi.mocked(fetchMostRecentBySource).mockResolvedValueOnce({
+      id: VALID_UUID,
+      title: 'Write Fail',
+      created_at: minutesAgo(2),
+    });
+    vi.mocked(hardDeleteNote).mockRejectedValueOnce(new Error('Delete failed'));
+    await expect(undoLatest(mockDb, MOCK_CONFIG)).rejects.toThrow('Delete failed');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `/undo` Telegram bot command that hard-deletes the most recent Telegram capture within the grace window (default 11 min)
- Only targets `source='telegram'` notes — never touches MCP or other agent captures
- Three outcomes: deleted (within grace window), refused (grace period passed → directs to MCP), or nothing to undo
- No soft-archive path — `/undo` is a true undo, not a general-purpose archive

### Files changed
- `mcp/src/db.ts` — `fetchMostRecentBySource()` helper (source-filtered query)
- `mcp/src/index.ts` — `CaptureService.undoLatest()` method (Service Binding RPC)
- `mcp/src/types.ts` — `UndoResult` type
- `src/index.ts` — `/undo` routing + `processUndo()` + shared `escapeHtml()`
- `src/types.ts` — `UndoResult` mirror + `undoLatest()` on `CaptureServiceStub`
- `tests/undo.test.ts` — 9 unit tests

## Test plan

- [x] Typecheck passes (both Workers)
- [x] 9 new undo unit tests pass (grace window, boundary, custom config, errors)
- [x] All 238 existing unit tests pass
- [ ] Deploy MCP Worker → Telegram Worker
- [ ] Capture a test note via Telegram, then `/undo` within grace window → verify deletion
- [ ] Send `/undo` with no recent Telegram captures → verify "Nothing to undo" message
- [ ] Wait for grace window to pass, then `/undo` → verify refusal message
- [ ] Register bot commands via `setMyCommands` API

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)