### PR TITLE
docs: gardener goal statement and ADR

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,6 +118,24 @@ The search threshold (`MCP_SEARCH_THRESHOLD`, default 0.35) is lower than the ca
 
 ## Gardener pipeline
 
+### Goal
+
+The gardener's job is to **complete the similarity graph that capture-time linking structurally cannot**. Capture-time linking has two blind spots:
+
+1. **Backward blindness.** When a fragment is captured, the pipeline finds the top 5 most similar existing notes and the LLM decides whether to link. But linking only looks backward — Monday's note never evaluates Tuesday's note. If Tuesday is a thematic neighbor, Monday will never initiate a link to it. The gardener compares all pairs regardless of creation order.
+
+2. **Context window truncation.** The capture pipeline presents only the top 5 candidates. In a dense topic, candidates 6–15 might all deserve links but the LLM never sees them. The gardener has no such limit — `find_similar_pairs` returns all pairs above threshold.
+
+A technical nuance: the comparison basis also differs. Capture-time matching compares raw text against augmented stored embeddings (`[Tags: ...] text`). The gardener compares augmented against augmented, so notes that share tags get a cosine boost the capture pipeline doesn't see.
+
+**Success looks like:** Every note that has a genuine thematic neighbor in the corpus is connected to it. A human browsing `get_related` for any note should see all the notes they'd group with it — not just the ones that happened to exist at capture time or fit in the top 5.
+
+**Failure looks like:** Notes about the same topic sit unconnected because one was captured after the other, or because the topic was too dense for the top-5 window. Entire input sources (e.g., short Telegram captures) are systematically excluded from similarity links. Clusters form without the gardener's contribution because its links are too sparse to matter.
+
+**How to test:** Pick 10 notes at random. For each, ask: does `get_related` surface all its thematic neighbors, or are some missing? Are any similarity links spurious — connecting notes a human wouldn't group together? Do short Telegram fragments get similarity links at a comparable rate to longer imports? If the answer to any of these is wrong, the threshold or the mechanism needs adjustment.
+
+### Operation
+
 The Gardener Worker runs similarity linking, with error isolation and best-effort alerting:
 
 ```

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1072,3 +1072,17 @@ Multi-resolution comparison is the simplest approach that captures real overlap.
 This confirms the design memo's signal quality caveat: current signals are proof-of-concept. Tag quality improvements (#151) and normalization (#147) are prerequisites for tags to carry useful clustering signal.
 
 **Source:** #152 experiment results, 2026-03-17.
+
+## Gardener similarity linking — purpose defined (2026-03-18)
+
+**Decision:** The gardener's similarity linking exists to complete the graph that capture-time linking structurally cannot. Two specific blind spots:
+
+1. **Backward blindness.** Capture-time linking only looks backward — a new note evaluates existing notes, but earlier notes never evaluate later arrivals. Monday's fragment never initiates a link to Tuesday's. The gardener compares all pairs regardless of creation order.
+
+2. **Context window truncation.** The capture pipeline presents only the top 5 candidates to the LLM. In a dense topic, candidates 6–15 might all deserve links but the LLM never sees them. The gardener's `find_similar_pairs` returns all pairs above threshold with no fixed candidate window.
+
+A supplementary mechanism difference: capture-time matching compares raw text against augmented stored embeddings, while the gardener compares augmented against augmented. Shared tags produce a cosine boost the capture pipeline doesn't see.
+
+**Why:** Five capture audits (2026-03-15 through 2026-03-18) consistently showed gardener links concentrated in dense obsidian-import clusters and absent from Telegram captures. The gardener produced only 36 `is-similar-to` links across 175 notes — too sparse to contribute to clustering. Articulating the purpose precisely was necessary before empirically tuning thresholds (#149, #158), so success and failure could be tested against a concrete goal rather than a vague sense of "more links."
+
+**Source:** #149 investigation session, 2026-03-18. Goal statement in `docs/architecture.md` → "Gardener pipeline → Goal."


### PR DESCRIPTION
## Summary
- Define the gardener's similarity linking purpose in `docs/architecture.md`: complete the graph that capture-time linking structurally cannot (backward blindness + context window truncation)
- Testable success/failure criteria and test protocol
- ADR in `docs/decisions.md` with audit evidence

Refs #149.

## Test plan
- [x] Docs-only change, no code impact