### PR TITLE
docs: restore gotchas from round-trip test

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -35,10 +35,10 @@
 # ── Restore ──────────────────────────────────────────────────────────────────
 #
 #   On a fresh or existing Supabase project:
-#     psql $DB_URL -c "CREATE EXTENSION IF NOT EXISTS vector"
-#     psql $DB_URL -f roles.sql
+#     psql $DB_URL -c "CREATE EXTENSION IF NOT EXISTS vector SCHEMA extensions"
+#     psql $DB_URL -f roles.sql    # errors on managed Supabase — roles already exist
 #     psql $DB_URL -f schema.sql
-#     psql $DB_URL -f data.sql
+#     psql $DB_URL -f data.sql     # ignore "permission denied" for auth/storage tables
 #
 # ── Customization ────────────────────────────────────────────────────────────
 #

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -344,13 +344,15 @@ Check the backup repository — you should see three files: `roles.sql`, `schema
 On a fresh Supabase project (or the same one after a disaster):
 
 ```bash
-psql $DB_URL -c "CREATE EXTENSION IF NOT EXISTS vector"
-psql $DB_URL -f roles.sql
+psql $DB_URL -c "CREATE EXTENSION IF NOT EXISTS vector SCHEMA extensions"
+psql $DB_URL -f roles.sql    # errors on managed Supabase — safe to ignore (roles already exist)
 psql $DB_URL -f schema.sql
-psql $DB_URL -f data.sql
+psql $DB_URL -f data.sql     # ignore "permission denied" for auth/storage internal tables
 ```
 
-Verify: note count matches, `match_notes` and `find_similar_pairs` RPCs work, `capture_profiles` seed data is present.
+The data dump includes Supabase internal schema tables (`auth`, `storage`) alongside your public schema. On managed Supabase projects, the internal tables fail with "permission denied" — this is harmless because those tables already exist. Your public schema data (notes, links, capture_profiles, etc.) restores cleanly.
+
+Verify: note count matches, `match_notes` and `find_similar_pairs` RPCs work, embeddings are queryable, `capture_profiles` seed data is present.
 
 ### Customization
 


### PR DESCRIPTION
## Summary

- Document that `roles.sql` errors are expected on managed Supabase (roles already exist)
- Document that `data.sql` includes internal schema tables (auth, storage) that fail with permission denied — harmless
- Add `SCHEMA extensions` to the `CREATE EXTENSION` restore command
- Update workflow header comments to match

Verified by full round-trip: dump from production → restore to throwaway Supabase project → 186 notes, 434 links, `match_notes`/`find_similar_pairs` RPCs all work with restored embeddings.

refs #159

## Test plan

- [x] Restore test passed on throwaway project (deleted after verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)