### PR TITLE
fix: scope data dump to public schema only

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -38,7 +38,7 @@
 #     psql $DB_URL -c "CREATE EXTENSION IF NOT EXISTS vector SCHEMA extensions"
 #     psql $DB_URL -f roles.sql    # errors on managed Supabase — roles already exist
 #     psql $DB_URL -f schema.sql
-#     psql $DB_URL -f data.sql     # ignore "permission denied" for auth/storage tables
+#     psql $DB_URL -f data.sql
 #
 # ── Customization ────────────────────────────────────────────────────────────
 #
@@ -75,7 +75,7 @@ jobs:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
 
       - name: Dump data
-        run: supabase db dump --db-url "$SUPABASE_DB_URL" --data-only --use-copy -f data.sql
+        run: supabase db dump --db-url "$SUPABASE_DB_URL" --data-only --use-copy --schema public -f data.sql
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -347,10 +347,10 @@ On a fresh Supabase project (or the same one after a disaster):
 psql $DB_URL -c "CREATE EXTENSION IF NOT EXISTS vector SCHEMA extensions"
 psql $DB_URL -f roles.sql    # errors on managed Supabase — safe to ignore (roles already exist)
 psql $DB_URL -f schema.sql
-psql $DB_URL -f data.sql     # ignore "permission denied" for auth/storage internal tables
+psql $DB_URL -f data.sql
 ```
 
-The data dump includes Supabase internal schema tables (`auth`, `storage`) alongside your public schema. On managed Supabase projects, the internal tables fail with "permission denied" — this is harmless because those tables already exist. Your public schema data (notes, links, capture_profiles, etc.) restores cleanly.
+The `roles.sql` step will show errors on managed Supabase — that's expected, the roles already exist. Schema and data restore cleanly.
 
 Verify: note count matches, `match_notes` and `find_similar_pairs` RPCs work, embeddings are queryable, `capture_profiles` seed data is present.
 


### PR DESCRIPTION
## Summary

- Add `--schema public` to the data dump command — excludes Supabase internal tables (auth, storage) that caused "permission denied" on restore
- Remove workaround documentation that told users to ignore those errors

The previous approach documented the errors instead of fixing them. This fixes the root cause.

refs #159

## Test plan

- [ ] Trigger `gh workflow run backup.yml` — verify data.sql no longer contains auth/storage tables
- [ ] Verify data.sql still contains notes, links, capture_profiles, enrichment_log, processed_updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)