### PR TITLE
docs: full documentation sweep for backup feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Every model is an environment variable. All AI calls route through OpenRouter �
 
 **No lock-in.** Postgres you can query and export any time. MCP means any compatible agent works — Claude, ChatGPT, Cursor, custom scripts. Switch tools whenever you want. The database doesn't care who's reading it. [Data ownership →](docs/philosophy.md#12-your-data-any-agent)
 
-**Daily backups included.** A GitHub Actions workflow dumps your database daily to a private repo you control — schema, data, and roles in three SQL files. Two secrets and one variable to configure. [Setup →](docs/setup.md#8-configure-automated-backups-optional)
+**Daily backups on the free tier.** A GitHub Actions workflow runs every night, dumping your entire database — notes, embeddings, links, RPC functions — to a private repo you control. Three SQL files, full git history as retention, zero cost. If something goes wrong, you restore with `psql` and your data is back. The workflow ships with the repo; you enable it by setting two secrets. [Setup →](docs/setup.md#8-configure-automated-backups-optional)
 
 The [full design philosophy](docs/philosophy.md) lays out the design principles with the reasoning behind each — not marketing copy, but the actual constraints the system is built against.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -201,6 +201,20 @@ Telegram can deliver the same webhook multiple times. The `processed_updates` ta
 
 This runs *before* the 200 response, so dedup is synchronous and guaranteed even if the background processing fails.
 
+## Automated backup
+
+The backup is not a Worker — it's a GitHub Actions workflow (`.github/workflows/backup.yml`) that runs daily at 04:00 UTC. It uses `supabase db dump` (which runs `pg_dump` inside a Docker container) to produce three SQL files:
+
+- **`roles.sql`** — database roles (`--role-only`)
+- **`schema.sql`** — DDL: tables, indexes, RPC functions, pgvector extension, RLS policies
+- **`data.sql`** — all row data in COPY format (`--data-only --use-copy --schema public`)
+
+The data dump is scoped to the `public` schema only — Supabase internal tables (`auth`, `storage`) are excluded. This means the dump restores cleanly to any Supabase project without permission errors.
+
+Dumps are pushed to a configurable private GitHub repository. Git history provides natural retention and deduplication — if nothing changed since the last backup, no commit is created. A verification step checks that dump files are non-empty, pgvector is present, RPC functions (`match_notes`, `find_similar_pairs`) are included, and notes data and `capture_profiles` seed exist.
+
+Authentication: the workflow uses a `SUPABASE_DB_URL` secret (session mode pooler connection string, port 5432) for the database connection, and a fine-grained `BACKUP_PAT` for push access to the backup repo.
+
 ## Future direction
 
 ### Fragment-first capture and synthesis layer

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1125,3 +1125,16 @@ A supplementary mechanism difference: capture-time matching compares raw text ag
 **Why:** Capture-time links are LLM-reasoned and typed (`contradicts`, `related`) — higher signal than gardener links (`is-similar-to`), which are mathematical proximity without reasoning about *why*. The architecture defines gardener links as supplementary: they "complete the similarity graph that capture-time linking structurally cannot." Pure confidence-descending ordering would invert this hierarchy because capture-time links have `confidence: null` (no cosine score stored). Ordering matters more as gardener link volume increases at the lower 0.65 threshold.
 
 **Source:** #149 investigation. Derived from architecture.md § Gardener Goal.
+
+## Backup implementation: separate private repo, public schema only (2026-03-18)
+
+**Decision:** Implementation choices for the automated backup workflow (#159):
+
+1. **Storage target: separate private GitHub repo.** Not an orphan branch in the main repo (data dumps could be exposed if the main repo is public), not GitHub Artifacts (90-day expiration), not R2 (unnecessary complexity for v1). Git history provides natural retention and deduplication.
+2. **Data dump scoped to `--schema public`.** The initial implementation dumped all schemas, which included Supabase internal tables (`auth`, `storage`) that failed with "permission denied" on restore. Scoping to `public` produces a clean dump that restores without errors.
+3. **Verification via loose grep.** `pg_dump` quotes identifiers (`"public"."notes"`, not `COPY public.notes`), so verification checks use loose string matching. Checks confirm: non-empty files, pgvector present, both RPC functions present, notes data present, `capture_profiles` seed present.
+4. **No `deploy.sh` integration.** The issue spec suggested an advisory check ("backup workflow not detected"). Skipped — the backup is orthogonal to the deploy pipeline and the setup guide covers it clearly.
+
+**Why:** Discovered during implementation and restore testing. The `--schema public` fix was the most significant — it turned a documented workaround into a clean solution. The quoting issue was caught by the first GitHub Actions run (schema dump is produced by Supabase's pg_dump Docker image, which quotes all identifiers).
+
+**Source:** #159 implementation, restore round-trip test on throwaway Supabase project (2026-03-18).

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -121,7 +121,9 @@ The irreducible core of ContemPlace is the database + MCP surface + gardening pi
 
 Your memory lives in Postgres you can always query and export. Any MCP-capable agent can read and write it. You stop being locked into any single agent's ecosystem. Today's LLM interprets your words one way; tomorrow's can reinterpret the same raw input with better understanding. Enrichment is always additive, never destructive.
 
-*Source: Product architecture crystallized during #27 design (2026-03-10). Reaffirmed in #93 (2026-03-13) and #116 (2026-03-14).*
+Ownership without recovery is a hollow promise. An automated daily backup dumps the full database — schema, data, embeddings, RPC functions — to a private repository you control. Three SQL files, restorable with `psql`, running on free tiers. Your data isn't just queryable; it's recoverable.
+
+*Source: Product architecture crystallized during #27 design (2026-03-10). Reaffirmed in #93 (2026-03-13) and #116 (2026-03-14). Backup as enforcement of data ownership: #96 investigation, #159 implementation (2026-03-18).*
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -125,6 +125,32 @@ This is the difference between a note store and a knowledge graph. The gardener 
 
 ---
 
+## Backups: what protects your data
+
+At 4am UTC — two hours after the gardener finishes — a GitHub Actions workflow dumps your entire database to a private repository you control. Three SQL files: roles, schema (tables, indexes, RPC functions, pgvector), and data (every note, embedding, link, and the capture voice profile). The whole thing runs on free tiers.
+
+You never interact with the backup. It runs in the background, commits to the backup repo if anything changed since the last run, and stays silent unless it fails. If it does fail, GitHub Actions shows the failure in the Actions tab, and optionally sends a Telegram alert.
+
+Git history in the backup repo is your retention. Each day's backup is a commit. You can diff two days to see what changed, roll back to any point, or clone the repo for an offline copy. At current scale (~200 notes), the dump is about 4MB — git handles this effortlessly.
+
+### Restoring
+
+If you need to recover — a botched migration, a deleted project, starting fresh on a new Supabase instance — the restore is three `psql` commands:
+
+```bash
+psql $DB_URL -c "CREATE EXTENSION IF NOT EXISTS vector SCHEMA extensions"
+psql $DB_URL -f schema.sql
+psql $DB_URL -f data.sql
+```
+
+Everything comes back: notes with embeddings intact, links, RPC functions, the capture voice profile. `match_notes` and `find_similar_pairs` work immediately — no re-embedding needed.
+
+### Setting it up
+
+The workflow ships with the repo (`.github/workflows/backup.yml`). To enable it: create a private backup repo, set two GitHub secrets and one variable, trigger it once to verify. Full instructions in the [setup guide](setup.md#8-configure-automated-backups-optional).
+
+---
+
 ## A day, start to finish
 
 Morning. You have a thought over coffee about how deadlines help creativity. You voice-dictate it into Telegram. The bot titles it, tags it, links it to a note from last week about constraints in design.
@@ -137,7 +163,9 @@ Evening. You capture two more thoughts from a conversation. One comes out wrong 
 
 2am. The gardener runs. Your morning thought about deadlines connects to a fragment about procrastination you captured three weeks ago. Tomorrow, when you think about either topic, the other is one hop away.
 
-You never organized anything. The structure emerged.
+4am. The backup runs. Your entire database — every note, embedding, link, and the capture voice profile — is dumped to a private repo. If anything goes wrong tomorrow, you restore with three commands and lose nothing.
+
+You never organized anything. The structure emerged. And the data is safe.
 
 ---
 


### PR DESCRIPTION
## Summary

Complete documentation sweep for the backup feature (#159). Every doc layer updated:

- **README** — expanded backup bullet for first-timers: free tier, automatic, restorable, ships with the repo
- **usage.md** — new "Backups: what protects your data" section with restore instructions and setup pointer; backup woven into the "A day, start to finish" narrative
- **philosophy.md** — principle 12 strengthened: "Ownership without recovery is a hollow promise"
- **architecture.md** — new "Automated backup" section: workflow mechanics, dump strategy, verification checks, auth
- **decisions.md** — implementation ADR: separate private repo, `--schema public`, loose grep for quoted identifiers, no deploy.sh integration

refs #159

## Test plan

- [x] All doc changes are prose-only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)