### PR TITLE
docs: clustering pipeline documentation sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,9 +71,10 @@ gardener/
   wrangler.toml      # Gardener Worker config (name: contemplace-gardener, cron: 0 2 * * *)
   tsconfig.json
   src/
-    index.ts         # scheduled() + fetch() exports — orchestrates similarity linking
-    config.ts        # Config loading (SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, thresholds)
-    db.ts            # Similarity DB ops
+    index.ts         # scheduled() + fetch() exports — orchestrates similarity linking + clustering
+    clustering.ts    # Louvain community detection via Graphology (multi-resolution, gravity, tag labels)
+    config.ts        # Config loading (thresholds, cosineFloor, clusterResolutions)
+    db.ts            # Similarity + cluster DB ops
     similarity.ts    # buildContext() — auto-generates link context from shared tags
     alert.ts         # sendAlert() — best-effort Telegram failure notification
     auth.ts          # validateTriggerAuth() — Bearer token auth for /trigger endpoint
@@ -86,6 +87,7 @@ supabase/
   migrations/
     20260314000000_v3_schema.sql   # Base schema (v3 — clean-slate, no type/intent/modality)
     20260315000000_v4_simplification.sql  # Schema simplification (drop SKOS, chunking, simplify links)
+    20260318000000_clusters_table.sql    # Clusters table for Louvain community detection results
 tests/
   parser.test.ts              # Unit tests for mcp/src/capture.ts parseCaptureResponse (no network)
   undo.test.ts                # Unit tests for /undo command (grace window, source filter, errors)
@@ -101,6 +103,7 @@ tests/
   semantic.test.ts            # Semantic correctness suite — tagging, linking, search quality (hits live stack)
   gardener-similarity.test.ts # Unit tests for buildContext() and UUID ordering deduplication
   gardener-config.test.ts     # Unit tests for gardener/src/config.ts loadConfig
+  gardener-clustering.test.ts # Unit tests for Louvain clustering (graph build, gravity, labels)
   gardener-alert.test.ts      # Unit tests for sendAlert() — Telegram alerting
   gardener-trigger.test.ts    # Unit tests for /trigger endpoint auth + routing
   gardener-integration.test.ts # Integration test: capture → gardener /trigger → get_related (live stack)
@@ -228,7 +231,7 @@ wrangler secret put GARDENER_API_KEY -c gardener/wrangler.toml          # option
 npx tsc --noEmit -p gardener/tsconfig.json
 
 # Run Gardener unit tests (local, no network)
-npx vitest run tests/gardener-similarity.test.ts tests/gardener-config.test.ts tests/gardener-alert.test.ts tests/gardener-trigger.test.ts
+npx vitest run tests/gardener-similarity.test.ts tests/gardener-config.test.ts tests/gardener-alert.test.ts tests/gardener-trigger.test.ts tests/gardener-clustering.test.ts
 
 # Run Gardener integration test (live stack — captures notes, triggers gardener, checks get_related)
 # Requires MCP_WORKER_URL, MCP_API_KEY, GARDENER_WORKER_URL, GARDENER_API_KEY in .dev.vars
@@ -326,9 +329,10 @@ The LLM returns this JSON and nothing else:
 
 ## Schema (v4)
 
-5 tables total:
+6 tables total:
 - `notes` — core notes with entities, corrections, summary, categories, metadata, archived_at, embedding, embedded_at, content_tsv
 - `links` — 3 link types: `contradicts`, `related` (capture-time), `is-similar-to` (gardening-time); includes context, confidence, created_by
+- `clusters` — pre-computed Louvain clusters (resolution, label, note_ids, top_tags, gravity, modularity); clean-slate per gardener run
 - `enrichment_log` — audit trail per note per enrichment type
 - `capture_profiles` — user-editable stylistic prompt rules; seeded with 'default' profile
 - `processed_updates` — Telegram dedup
@@ -359,7 +363,7 @@ Verify: `curl "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getWebhookInfo"
 - **v4.0.0 (complete):** Schema simplification bundle (#128, PR #131). Dropped 3 tables (concepts, note_concepts, note_chunks), 3 columns (refined_tags, maturity, importance_score), 2 RPC functions (match_chunks, batch_update_refined_tags). Link types simplified from 9 → 3 (contradicts, related, is-similar-to). MCP tools reduced from 8 → 5. Gardener simplified to similarity linking only.
 - **remove_note (complete):** MCP tool for note removal with time-dependent behavior (#87, PR #140). Notes < 11 min: permanently deleted. Older: soft archive. All existing tools now filter `archived_at IS NULL`. Renamed from `archive_note` — the old name promised archival but could permanently delete.
 - **Telegram /undo (complete):** `/undo` command hard-deletes most recent Telegram capture within grace window (#142, PR #143). Source-scoped (Telegram only), grace-window-only (refuses after 11 min). Bot commands registered automatically by `deploy.sh`.
-- **Cluster exploration (active design phase):** Louvain community detection via Graphology. Experiment (#152) validated cosine-only as starting point — 3 coherent clusters at resolution 1.0 across 164 notes. Multi-resolution overlap model (134/164 notes change cluster across resolutions). Tags and links are an upgrade path pending quality improvements (#151, #147). Gardener-time computation, `list_clusters` MCP tool reads pre-computed results. Implementation next (#144).
+- **Cluster exploration (implementation in progress):** Louvain community detection via Graphology. PR 1 of 2 delivered (#156, PR #164): gardener computes multi-resolution clusters (cosine-only) and stores in `clusters` table. Verified against 186 notes — 9 clusters at res 1.0, coherent labels. PR 2 of 2 pending: `list_clusters` MCP tool reads pre-computed results. Tags, links, entities are upgrade paths (#151, #147, #125).
 - **Phase 3 (deferred):** Associative trails, location extraction.
 
 ## Deploy

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,7 @@ OpenRouter sits between the Workers and all AI models. This adds a hop but means
 |---|---|---|---|
 | **Telegram capture** | `contemplace` | Receives Telegram webhooks, delegates capture to MCP Worker via Service Binding, formats HTML reply | Telegram webhook POST |
 | **MCP server** | `mcp-contemplace` | MCP tools via JSON-RPC 2.0 over HTTP. Hosts `CaptureService` entrypoint for Service Binding RPC (`capture()` + `undoLatest()`). | HTTP POST /mcp, Service Binding RPC |
-| **Gardener** | `contemplace-gardener` | Nightly enrichment: similarity linking | Cron (02:00 UTC) or POST /trigger |
+| **Gardener** | `contemplace-gardener` | Nightly enrichment: similarity linking + cluster detection | Cron (02:00 UTC) or POST /trigger |
 
 Each Worker is independently deployed with its own `wrangler.toml` and secrets. They share the same Supabase database and use the same `openai` SDK pattern for OpenRouter calls.
 
@@ -136,19 +136,35 @@ A technical nuance: the comparison basis also differs. Capture-time matching com
 
 ### Operation
 
-The Gardener Worker runs similarity linking, with error isolation and best-effort alerting:
+The Gardener Worker runs two phases — similarity linking and cluster detection — with error isolation and best-effort alerting:
 
 ```
  Cron trigger (02:00 UTC) or POST /trigger
        │
        ▼
  ┌─────────────────────────────────┐
- │  Similarity linking             │
- │  • find_similar_pairs() RPC     │
- │  • Clean-slate delete + reinsert│
- │  • Auto-context from shared     │
- │    tags                         │
- └─────────────────────────────────┘
+ │  1. Fetch shared data           │
+ │     • fetchNotesForSimilarity   │
+ │     • find_similar_pairs at     │
+ │       cosineFloor (0.40)        │
+ └──────────────┬──────────────────┘
+                │
+       ┌────────┴────────┐
+       ▼                 ▼
+ ┌───────────────┐ ┌───────────────┐
+ │ 2. Similarity │ │ 3. Clustering │
+ │    linking    │ │    (try/catch)│
+ │ • Filter pairs│ │ • Graphology  │
+ │   >= 0.65     │ │   graph build │
+ │ • Clean-slate │ │ • Louvain at  │
+ │   delete +    │ │   each        │
+ │   reinsert    │ │   resolution  │
+ │ • Context from│ │ • Gravity +   │
+ │   shared tags │ │   tag labels  │
+ └───────────────┘ │ • Clean-slate │
+                   │   delete +    │
+                   │   insert      │
+                   └───────────────┘
        │
        ▼  on any error
  ┌─────────────────────────────────┐
@@ -156,6 +172,10 @@ The Gardener Worker runs similarity linking, with error isolation and best-effor
  │  (if TELEGRAM_BOT_TOKEN set)    │
  └─────────────────────────────────┘
 ```
+
+The orchestrator fetches pairs once at `GARDENER_COSINE_FLOOR` (0.40) and shares them between phases. Pairs >= `GARDENER_SIMILARITY_THRESHOLD` (0.65) go to the linker; all pairs go to clustering. Clustering failure is isolated via try/catch — it never kills the gardener run or affects similarity links.
+
+Cluster detection uses Louvain community detection via Graphology (pure JS, runs in CF Workers V8). Multi-resolution: runs at each value in `GARDENER_CLUSTER_RESOLUTIONS` (default 1.0, 1.5, 2.0). Higher resolution = more granular clusters. Results stored in the `clusters` table with gravity (recency-weighted size) and top-3 tag labels.
 
 Subrequest budget is minimal and well within CF Workers' 50 free-tier limit, thanks to the `find_similar_pairs` batch RPC function.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1138,3 +1138,27 @@ A supplementary mechanism difference: capture-time matching compares raw text ag
 **Why:** Discovered during implementation and restore testing. The `--schema public` fix was the most significant — it turned a documented workaround into a clean solution. The quoting issue was caught by the first GitHub Actions run (schema dump is produced by Supabase's pg_dump Docker image, which quotes all identifiers).
 
 **Source:** #159 implementation, restore round-trip test on throwaway Supabase project (2026-03-18).
+
+## Gardener clustering: cosine-only Louvain with shared pair fetch (2026-03-18)
+
+**Decision:** Implement cluster detection as a second gardener phase using Graphology's Louvain `.detailed()` with cosine-only edge weights. Fetch all pairs at `GARDENER_COSINE_FLOOR` (0.40) once and share between similarity linking (filtered >= 0.65) and clustering (all pairs). Store pre-computed results in a `clusters` table with clean-slate-per-run semantics.
+
+**Why:** The #152 experiment validated that cosine similarity alone produces coherent clusters (3 real domains at resolution 1.0 across 164 notes). Tags contribute marginal signal (5.4% pair overlap), and links reinforce rather than reshape cosine structure. Starting cosine-only keeps the implementation simple; tags, links, and entities become upgrade paths as signal quality improves (#151, #147, #125). Shared pair fetch saves one RPC round-trip per gardener run. Clustering failure is isolated via try/catch — it never affects the core similarity linker.
+
+**Source:** #153 (implementation spec), #156 (PR 1 of 2), #152 (experiment validation). PR #164.
+
+## Gravity formula: recency-weighted size (2026-03-18)
+
+**Decision:** Cluster gravity = `size × avg(1 / (1 + age_days))`. Intentionally biases toward clusters with recent activity.
+
+**Why:** A small cluster about something you're actively working on should outrank a large stale cluster. Pure size ranking would bury current work under historical accumulation. The `1/(1+age)` decay function gives today's note full weight (1.0) and a year-old note ~0.003. This matches the product philosophy: ContemPlace surfaces what's currently on your mind, not just what's historically dense.
+
+**Source:** #153 design spec. Confirmed during specialist review of PR #164.
+
+## Labels from tag aggregation, not LLM (2026-03-18)
+
+**Decision:** Cluster labels are derived from top-3 most frequent tags across members. No LLM calls. Format: `"tag1 / tag2 / tag3"`. Fallback: `"Cluster (N notes)"` when no tags exist.
+
+**Why:** The gardener stays LLM-free — all computation is deterministic and mathematical. Tag labels are sufficient for browsing (verified against live clusters: "pen-plotting / printmaking / generative-art" is immediately meaningful). LLM-generated narrative labels are an upgrade path but add cost, latency, and non-determinism to a nightly batch that should be cheap and reliable.
+
+**Source:** #153 design spec. Live verification against 186-note corpus confirmed label quality.

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,7 +15,8 @@ npx vitest run tests/parser.test.ts tests/undo.test.ts \
   tests/mcp-tools.test.ts tests/mcp-dispatch.test.ts \
   tests/mcp-index.test.ts tests/mcp-oauth.test.ts \
   tests/gardener-similarity.test.ts tests/gardener-config.test.ts \
-  tests/gardener-alert.test.ts tests/gardener-trigger.test.ts
+  tests/gardener-alert.test.ts tests/gardener-trigger.test.ts \
+  tests/gardener-clustering.test.ts
 
 # Or individually:
 npx vitest run tests/parser.test.ts              # Capture response parsing
@@ -24,6 +25,7 @@ npx vitest run tests/mcp-tools.test.ts           # All 6 MCP tool handlers
 npx vitest run tests/mcp-dispatch.test.ts        # JSON-RPC dispatch
 npx vitest run tests/mcp-oauth.test.ts           # Consent page + AuthHandler
 npx vitest run tests/mcp-index.test.ts           # OAuthProvider + resolveExternalToken
+npx vitest run tests/gardener-clustering.test.ts # Louvain clustering (graph build, gravity, labels)
 ```
 
 ### Smoke tests (live workers, requires `.dev.vars`)
@@ -107,14 +109,15 @@ mcp/              MCP Worker (JSON-RPC 2.0 over HTTP)
     capture.ts    System frame, LLM call, response parser (parseCaptureResponse)
     types.ts      MCP-specific TypeScript interfaces + ServiceCaptureResult
   wrangler.toml
-gardener/         Gardener Worker (nightly similarity linking)
+gardener/         Gardener Worker (nightly similarity linking + cluster detection)
   src/
-    index.ts      Cron-triggered entry point — orchestrates similarity linking
+    index.ts      Cron-triggered entry point — orchestrates similarity linking + clustering
+    clustering.ts Louvain community detection via Graphology (multi-resolution, gravity, tag labels)
     similarity.ts Link context builder (shared tags)
-    db.ts         Supabase operations (similarity linking)
+    db.ts         Supabase operations (similarity linking + cluster storage)
     alert.ts      Best-effort Telegram failure notification
     auth.ts       Bearer token auth for /trigger endpoint
-    config.ts     Config loading with threshold validation
+    config.ts     Config loading with threshold + clustering config validation
     types.ts      TypeScript interfaces
   wrangler.toml
 .claude/
@@ -142,7 +145,8 @@ tests/
   mcp-dispatch.test.ts    JSON-RPC dispatch
   mcp-smoke.test.ts       Live MCP Worker + OAuth discovery
   gardener-similarity.test.ts  buildContext + UUID dedup
-  gardener-config.test.ts      Gardener config loading
+  gardener-config.test.ts      Gardener config loading (thresholds, cosineFloor, resolutions)
+  gardener-clustering.test.ts  Louvain clustering (graph build, gravity, labels, singletons)
   gardener-alert.test.ts       Telegram failure alerting
   gardener-trigger.test.ts     /trigger endpoint auth + routing
   gardener-integration.test.ts capture → gardener → get_related

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -175,38 +175,51 @@ The workflow includes verification checks (non-empty files, pgvector presence, R
 
 Documented in `docs/setup.md` section 8 as a user-configurable feature — any ContemPlace fork enables daily backup by adding three GitHub settings.
 
-## Cluster exploration — active design phase
+## Cluster exploration — implementation in progress
 
 The synthesis layer (#120) was designed as MOC generation from fragment clusters. A first-principles design session (2026-03-16) reframed the question: the real use case isn't narrative summarization — it's **undirected browsing**. Seeing the shape of your thinking without knowing what you're looking for. The Obsidian graph view served this; nothing in the current MCP surface does.
 
-A literature review and design session (2026-03-17) produced concrete design decisions:
+### Gardener clustering pipeline — delivered (PR #164, 2026-03-18)
 
-- **Approach:** Weighted graph fusion combining embeddings (cosine similarity), tags (Jaccard co-occurrence), explicit links, and eventually entities into a single weighted edge. Weights are tunable parameters.
-- **Algorithm:** Louvain community detection via Graphology (TypeScript-native, works in V8). Custom implementation not ruled out.
-- **Structure:** Flat clusters with overlap — no hierarchy, no nesting. A resolution parameter controls granularity; the consumer picks the zoom level. Hard assignment rejected; multi-membership from day one.
+PR 1 of 2: the gardener now computes Louvain clusters and stores them in the DB. Deployed and verified against 186 notes.
+
+Delivered:
+- **`clusters` table** with RLS deny-all — resolution, label, note_ids, top_tags, gravity, modularity
+- **Graphology integration** — pure JS graph library running in CF Workers V8 (119KB gzip, 659KB total bundle)
+- **Multi-resolution Louvain** — runs `.detailed()` at each resolution in `GARDENER_CLUSTER_RESOLUTIONS` (default 1.0, 1.5, 2.0)
+- **Orchestrator refactoring** — single `find_similar_pairs` call at `GARDENER_COSINE_FLOOR` (0.40), filtered >= `GARDENER_SIMILARITY_THRESHOLD` (0.65) for linker, full set to clustering
+- **Error isolation** — clustering failure logged but never kills the gardener run
+- **Gravity** — `size × avg(1 / (1 + age_days))` — recency-weighted, biases toward active clusters
+- **Labels** — top-3 most frequent tags, no LLM calls (gardener stays LLM-free)
+
+Live results (186 notes): 9 clusters at res 1.0 (modularity 0.60), 11 at 1.5, 12 at 2.0. Coherent labels: pen-plotting/printmaking/generative-art, laser-cutting/instrument-design, audio-plugin/plugdata/sound-soup, note-taking/knowledge-capture, contemplace/mcp/knowledge-management.
+
+### Design decisions
+
+- **Approach:** Weighted graph fusion combining embeddings (cosine similarity), tags (Jaccard co-occurrence), explicit links, and eventually entities into a single weighted edge. v1 is cosine-only; signals are an upgrade path.
+- **Algorithm:** Louvain community detection via Graphology (TypeScript-native, works in V8).
+- **Structure:** Flat clusters with overlap — no hierarchy, no nesting. Resolution controls granularity; multi-membership via multi-resolution comparison.
 - **Computation:** Gardener-time, stored in DB. A `list_clusters` MCP tool reads pre-computed results.
-- **Labels:** LLM-assisted at gardening time for dashboard-browseable cluster names.
-- **Gravity:** Recency-weighted, not just size — new clusters about current work should surface even when small.
+- **Labels:** Top-N tag aggregation (LLM-free). LLM-assisted labels are an upgrade path.
+- **Gravity:** Recency-weighted, not just size — new clusters about current work surface even when small.
 
 ### Experiment results (#152, 2026-03-17)
 
 A local experiment script (`scripts/cluster-experiment.ts`) ran weighted graph clustering against the live corpus (164 notes) with 6 weight configurations across 4 resolutions. Key findings:
 
-- **Cosine-only produces coherent clusters.** At resolution 1.0, three clusters map to real domains: ContemPlace/PKM (74 notes), making/instruments (57 notes), pen-plotting/art (33 notes).
-- **Resolution is the most useful parameter.** 0.5 → 1 cluster, 1.0 → 3, 1.5 → 6, 2.0 → 9+. Genuinely controls zoom level.
-- **Tags add marginal signal.** Only 5.4% of note pairs share any tag. Tag Jaccard is near-zero for most edges.
-- **Links reinforce cosine.** Adding gardener links moved only 9/164 notes vs the cosine baseline.
-- **Overlap is real.** 134/164 notes change cluster across resolutions. Modularity is low (0.27–0.32) — soft boundaries, expected for a commonplace book.
+- **Cosine-only produces coherent clusters.** At resolution 1.0, three clusters map to real domains.
+- **Resolution is the most useful parameter.** 0.5 → 1 cluster, 1.0 → 3, 1.5 → 6, 2.0 → 9+.
+- **Tags add marginal signal.** Only 5.4% of note pairs share any tag.
+- **Overlap is real.** 134/164 notes change cluster across resolutions. Modularity is low (0.27–0.32).
 
-**Decision:** Start with cosine-only clustering. The fusion formula (tags, links, entities) becomes an upgrade path as signal quality improves. Multi-resolution Louvain is the overlap model. See `docs/decisions.md` for the full ADRs.
-
-**Sequenced next steps:**
-1. ~~**#152** — Experiment: weighted graph clustering against live corpus~~ **Done.** Validated cosine-only, resolution parameter, multi-resolution overlap.
-2. **#149** — Threshold assessment (elevated to key product feature)
-3. **#151** — Capture-time tag quality and consistency (quantified: 478 unique tags, 5.4% pair overlap)
-4. **#147** — Gardener-time tag normalization
-5. **#144** — Gardener clustering pipeline + `list_clusters` tool (cosine-only first iteration)
-6. **#125** — Entity dictionary (fourth clustering signal)
+### Next steps
+1. ~~**#152** — Experiment~~ **Done.**
+2. ~~**#156** — Gardener clustering pipeline (PR 1 of 2)~~ **Done.** (PR #164)
+3. **PR 2 of 2** — `list_clusters` MCP tool (reads pre-computed clusters)
+4. **#149** — Threshold assessment
+5. **#151** — Capture-time tag quality and consistency
+6. **#147** — Gardener-time tag normalization
+7. **#125** — Entity dictionary (fourth clustering signal)
 
 **Related:** #120 (synthesis — may be unnecessary if cluster exploration suffices), #101 (visual dashboard — cluster data is primary input)
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -2,7 +2,7 @@
 
 *The database contract — all tables, columns, RPC functions, and indexes. Read this if you're querying the database directly or writing a migration.*
 
-The v4 schema has 5 tables, 2 RPC functions, and indexes optimized for both vector similarity search and traditional filtering. All tables have RLS enabled with `deny all` policies — access is exclusively via the service role key.
+The v4 schema has 6 tables, 2 RPC functions, and indexes optimized for both vector similarity search and traditional filtering. All tables have RLS enabled with `deny all` policies — access is exclusively via the service role key.
 
 ## Tables
 
@@ -93,6 +93,23 @@ Stores the stylistic prompt rules (the "capture voice") fetched at runtime by an
 
 Edit the `default` row to tune capture behavior without redeploying.
 
+### clusters
+
+Pre-computed Louvain community detection results. Clean-slate per gardener run — all rows deleted and re-inserted.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid (PK) | |
+| `resolution` | float | Louvain resolution parameter (e.g. 1.0, 1.5, 2.0) |
+| `label` | text | Human-readable label from top tags (e.g. "cooking / italian / pasta") |
+| `note_ids` | uuid[] | Member note IDs |
+| `top_tags` | text[] | Top-3 most frequent tags across members |
+| `gravity` | float | Recency-weighted size: `size × avg(1 / (1 + age_days))` |
+| `modularity` | float | Louvain modularity score for this resolution |
+| `created_at` | timestamptz | |
+
+**Index:** `clusters_resolution_idx` (B-tree on `resolution`) for filtering by zoom level.
+
 ### processed_updates
 
 Telegram deduplication. Stores each `update_id` to prevent reprocessing.
@@ -134,7 +151,7 @@ Self-join cosine similarity search across all notes. Replaces N individual `matc
 ```sql
 find_similar_pairs(
   similarity_threshold  float  DEFAULT 0.7,
-  max_pairs             int    DEFAULT 500
+  max_pairs             int    DEFAULT 10000
 )
 ```
 
@@ -142,7 +159,7 @@ Returns: `note_a`, `note_b`, `similarity`. Orders pairs with `note_a < note_b` t
 
 ## Row Level Security
 
-All 5 tables have RLS enabled with a single `deny all` policy. This means:
+All 6 tables have RLS enabled with a single `deny all` policy. This means:
 
 - The **anon key** has zero access to any table
 - The **service role key** bypasses RLS entirely (by design)


### PR DESCRIPTION
## Summary

Post-merge documentation sweep for the gardener clustering pipeline (PR #164).

- `docs/schema.md` — add `clusters` table (6 tables now), fix `find_similar_pairs` `max_pairs` default (500 → 10000)
- `docs/architecture.md` — update gardener pipeline diagram with clustering phase, shared pair fetch pattern
- `docs/roadmap.md` — mark #156 as delivered, update next steps sequence
- `docs/development.md` — add `clustering.ts` to layout, `gardener-clustering.test.ts` to test commands
- `docs/decisions.md` — 3 new ADRs: cosine-only Louvain, gravity formula, tag-based labels
- `CLAUDE.md` — update project layout, schema count, phase scope, test commands

## Test plan

- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)