### PR TITLE
feat: list_clusters MCP tool (PR 2/2)

### DIFF
--- a/mcp/src/db.ts
+++ b/mcp/src/db.ts
@@ -1,6 +1,6 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import type { Config } from './config';
-import type { CaptureLink, CaptureResult, MatchedNote, NoteRow, LinkWithTitle } from './types';
+import type { CaptureLink, CaptureResult, MatchedNote, NoteRow, LinkWithTitle, ClusterRow, ClusterNote } from './types';
 
 export type SupabaseClientType = SupabaseClient;
 
@@ -267,6 +267,72 @@ export async function searchNotes(
   }
 
   return (data as MatchedNote[]) ?? [];
+}
+
+// ── Cluster functions ─────────────────────────────────────────────────────
+
+export interface ClusterWithNotes {
+  label: string;
+  top_tags: string[];
+  note_count: number;
+  gravity: number;
+  notes: ClusterNote[];
+}
+
+// Fetch clusters at a given resolution, with note titles resolved.
+// Archived notes are silently filtered out at read time.
+export async function fetchClusters(
+  db: SupabaseClient,
+  resolution: number,
+): Promise<{ clusters: ClusterWithNotes[]; computed_at: string | null }> {
+  const { data: clusterRows, error } = await db
+    .from('clusters')
+    .select('label, top_tags, note_ids, gravity, modularity, created_at')
+    .eq('resolution', resolution)
+    .order('gravity', { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to fetch clusters: ${error.message}`);
+  }
+
+  const rows = (clusterRows as ClusterRow[] | null) ?? [];
+  if (rows.length === 0) {
+    return { clusters: [], computed_at: null };
+  }
+
+  // Collect all note IDs across all clusters
+  const allNoteIds = [...new Set(rows.flatMap(r => r.note_ids))];
+
+  // Batch-fetch titles (respecting archived_at IS NULL)
+  const { data: noteRows } = await db
+    .from('notes')
+    .select('id, title')
+    .in('id', allNoteIds)
+    .is('archived_at', null);
+
+  const titleMap = new Map<string, string>();
+  if (noteRows) {
+    for (const n of noteRows as Array<{ id: string; title: string }>) {
+      titleMap.set(n.id, n.title);
+    }
+  }
+
+  // Map titles back to clusters, filter out archived notes
+  const clusters: ClusterWithNotes[] = rows.map(row => {
+    const activeNotes: ClusterNote[] = row.note_ids
+      .filter(id => titleMap.has(id))
+      .map(id => ({ id, title: titleMap.get(id)! }));
+
+    return {
+      label: row.label,
+      top_tags: row.top_tags,
+      note_count: activeNotes.length,
+      gravity: row.gravity,
+      notes: activeNotes,
+    };
+  });
+
+  return { clusters, computed_at: rows[0]!.created_at };
 }
 
 // ── Undo functions ────────────────────────────────────────────────────────

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -4,7 +4,7 @@ import { createClient } from '@supabase/supabase-js';
 import { loadConfig } from './config';
 import { timingSafeEqual } from './auth';
 import { createOpenAIClient } from './embed';
-import { TOOL_DEFINITIONS, handleSearchNotes, handleGetNote, handleListRecent, handleGetRelated, handleCaptureNote, handleRemoveNote } from './tools';
+import { TOOL_DEFINITIONS, handleSearchNotes, handleGetNote, handleListRecent, handleGetRelated, handleCaptureNote, handleRemoveNote, handleListClusters } from './tools';
 import { runCapturePipeline } from './pipeline';
 import { AuthHandler } from './oauth';
 import type { Env, ServiceCaptureResult, UndoResult } from './types';
@@ -104,6 +104,9 @@ export async function handleMcpRequest(request: Request, env: Env): Promise<Resp
         break;
       case 'remove_note':
         result = await handleRemoveNote(args, db, config);
+        break;
+      case 'list_clusters':
+        result = await handleListClusters(args, db);
         break;
       default:
         return jsonRpcError(id, -32601, `Unknown tool: ${toolName}`);

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -2,7 +2,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import type OpenAI from 'openai';
 import type { Config } from './config';
 import { embedText } from './embed';
-import { fetchNote, fetchNoteLinks, listRecentNotes, searchNotes, fetchNoteForArchive, archiveNote, hardDeleteNote } from './db';
+import { fetchNote, fetchNoteLinks, listRecentNotes, searchNotes, fetchNoteForArchive, archiveNote, hardDeleteNote, fetchClusters } from './db';
 import { runCapturePipeline } from './pipeline';
 
 // ── Validation helpers ────────────────────────────────────────────────────────
@@ -91,6 +91,20 @@ export const TOOL_DEFINITIONS = [
         id: { type: 'string', description: 'UUID of the note to remove' },
       },
       required: ['id'],
+    },
+  },
+  {
+    name: 'list_clusters',
+    description: 'List thematic clusters detected by the gardener. Clusters group notes by semantic similarity — call with no parameters to see the landscape of accumulated thinking. Use resolution to control granularity: 1.0 (broad themes), 1.5 (finer distinctions), 2.0 (narrow topics).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        resolution: {
+          type: 'number',
+          description: 'Cluster resolution (default 1.0). Available: 1.0, 1.5, 2.0. Lower = fewer larger clusters.',
+        },
+      },
+      required: [],
     },
   },
 ];
@@ -246,5 +260,35 @@ export async function handleRemoveNote(
   } catch (err) {
     console.error(JSON.stringify({ event: 'remove_note_error', error: String(err), id }));
     return toolError('Archive operation failed. Try again.');
+  }
+}
+
+export async function handleListClusters(
+  args: Record<string, unknown>,
+  db: SupabaseClient,
+): Promise<object> {
+  const resolution = typeof args['resolution'] === 'number' ? args['resolution'] : 1.0;
+
+  try {
+    const { clusters, computed_at } = await fetchClusters(db, resolution);
+
+    const clusteredNotes = clusters.reduce((sum, c) => sum + c.note_count, 0);
+
+    return toolSuccess({
+      clusters: clusters.map(c => ({
+        label: c.label,
+        top_tags: c.top_tags,
+        note_count: c.note_count,
+        gravity: c.gravity,
+        notes: c.notes,
+      })),
+      resolution,
+      cluster_count: clusters.length,
+      clustered_notes: clusteredNotes,
+      computed_at,
+    });
+  } catch (err) {
+    console.error(JSON.stringify({ event: 'list_clusters_error', error: String(err) }));
+    return toolError('Failed to fetch clusters. Try again.');
   }
 }

--- a/mcp/src/types.ts
+++ b/mcp/src/types.ts
@@ -83,6 +83,22 @@ export interface LinkWithTitle {
   direction: 'outbound' | 'inbound';
 }
 
+// ── Cluster types ───────────────────────────────────────────────────────────
+
+export interface ClusterNote {
+  id: string;
+  title: string;
+}
+
+export interface ClusterRow {
+  label: string;
+  top_tags: string[];
+  note_ids: string[];
+  gravity: number;
+  modularity: number | null;
+  created_at: string;
+}
+
 // ── Undo result ─────────────────────────────────────────────────────────────
 // Returned by CaptureService.undoLatest() — safe for structured cloning across Service Bindings.
 

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -22,6 +22,7 @@ vi.mock('../mcp/src/db', () => ({
   fetchNoteForArchive: vi.fn().mockResolvedValue(null),
   archiveNote: vi.fn().mockResolvedValue(undefined),
   hardDeleteNote: vi.fn().mockResolvedValue(undefined),
+  fetchClusters: vi.fn().mockResolvedValue({ clusters: [], computed_at: null }),
 }));
 
 vi.mock('../mcp/src/embed', () => ({
@@ -50,6 +51,7 @@ import {
   handleGetRelated,
   handleCaptureNote,
   handleRemoveNote,
+  handleListClusters,
 } from '../mcp/src/tools';
 import {
   searchNotes,
@@ -64,6 +66,7 @@ import {
   fetchNoteForArchive,
   archiveNote,
   hardDeleteNote,
+  fetchClusters,
 } from '../mcp/src/db';
 import { embedText } from '../mcp/src/embed';
 import { runCaptureAgent } from '../mcp/src/capture';
@@ -756,6 +759,106 @@ describe('handleRemoveNote', () => {
       const body = JSON.parse(r.content[0]!.text);
       expect(body.deleted).toBe(true);
       expect(vi.mocked(hardDeleteNote)).toHaveBeenCalledOnce();
+    });
+  });
+});
+
+// ── handleListClusters ───────────────────────────────────────────────────────
+
+const MOCK_CLUSTER = {
+  label: 'cooking / italian / pasta',
+  top_tags: ['cooking', 'italian', 'pasta'],
+  note_count: 3,
+  gravity: 2.5,
+  notes: [
+    { id: 'aaaaaaaa-0000-0000-0000-000000000001', title: 'Homemade pasta basics' },
+    { id: 'aaaaaaaa-0000-0000-0000-000000000002', title: 'Italian cooking philosophy' },
+    { id: 'aaaaaaaa-0000-0000-0000-000000000003', title: 'Pasta shapes and sauces' },
+  ],
+};
+
+describe('handleListClusters', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  describe('defaults', () => {
+    it('defaults resolution to 1.0 when not provided', async () => {
+      await handleListClusters({}, mockDb);
+      expect(vi.mocked(fetchClusters)).toHaveBeenCalledWith(mockDb, 1.0);
+    });
+
+    it('passes through a provided resolution', async () => {
+      await handleListClusters({ resolution: 2.0 }, mockDb);
+      expect(vi.mocked(fetchClusters)).toHaveBeenCalledWith(mockDb, 2.0);
+    });
+
+    it('defaults resolution to 1.0 when non-numeric value provided', async () => {
+      await handleListClusters({ resolution: 'bad' }, mockDb);
+      expect(vi.mocked(fetchClusters)).toHaveBeenCalledWith(mockDb, 1.0);
+    });
+  });
+
+  describe('empty state', () => {
+    it('returns empty clusters when gardener has not run', async () => {
+      vi.mocked(fetchClusters).mockResolvedValueOnce({ clusters: [], computed_at: null });
+      const r = toolResult(await handleListClusters({}, mockDb));
+      expect(r.isError).toBe(false);
+      const body = JSON.parse(r.content[0]!.text);
+      expect(body.cluster_count).toBe(0);
+      expect(body.clusters).toEqual([]);
+      expect(body.computed_at).toBeNull();
+    });
+  });
+
+  describe('happy path', () => {
+    it('returns clusters with correct structure', async () => {
+      vi.mocked(fetchClusters).mockResolvedValueOnce({
+        clusters: [MOCK_CLUSTER],
+        computed_at: '2026-03-18T02:00:00.000Z',
+      });
+      const r = toolResult(await handleListClusters({}, mockDb));
+      expect(r.isError).toBe(false);
+      const body = JSON.parse(r.content[0]!.text);
+      expect(body.cluster_count).toBe(1);
+      expect(body.resolution).toBe(1.0);
+      expect(body.clustered_notes).toBe(3);
+      expect(body.computed_at).toBe('2026-03-18T02:00:00.000Z');
+    });
+
+    it('returns cluster fields correctly', async () => {
+      vi.mocked(fetchClusters).mockResolvedValueOnce({
+        clusters: [MOCK_CLUSTER],
+        computed_at: '2026-03-18T02:00:00.000Z',
+      });
+      const r = toolResult(await handleListClusters({}, mockDb));
+      const body = JSON.parse(r.content[0]!.text);
+      const cluster = body.clusters[0];
+      expect(cluster.label).toBe('cooking / italian / pasta');
+      expect(cluster.top_tags).toEqual(['cooking', 'italian', 'pasta']);
+      expect(cluster.note_count).toBe(3);
+      expect(cluster.gravity).toBe(2.5);
+      expect(cluster.notes).toHaveLength(3);
+      expect(cluster.notes[0].title).toBe('Homemade pasta basics');
+    });
+
+    it('sums clustered_notes across multiple clusters', async () => {
+      const cluster2 = { ...MOCK_CLUSTER, label: 'music / jazz', note_count: 5, notes: Array(5).fill(MOCK_CLUSTER.notes[0]) };
+      vi.mocked(fetchClusters).mockResolvedValueOnce({
+        clusters: [MOCK_CLUSTER, cluster2],
+        computed_at: '2026-03-18T02:00:00.000Z',
+      });
+      const r = toolResult(await handleListClusters({}, mockDb));
+      const body = JSON.parse(r.content[0]!.text);
+      expect(body.clustered_notes).toBe(8);
+      expect(body.cluster_count).toBe(2);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns toolError when fetchClusters throws', async () => {
+      vi.mocked(fetchClusters).mockRejectedValueOnce(new Error('DB error'));
+      const r = toolResult(await handleListClusters({}, mockDb));
+      expect(r.isError).toBe(true);
+      expect(r.content[0]!.text).toMatch(/Failed to fetch clusters/);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Exposes pre-computed Louvain clusters to agents via a read-only `list_clusters` MCP tool (PR 2 of 2 for #153)
- Resolution parameter controls granularity: 1.0 (broad), 1.5 (finer), 2.0 (narrow)
- Clusters ordered by gravity (recent active topics first)
- Note titles resolved at read time — archived notes silently filtered out
- Empty state returns `{ clusters: [], cluster_count: 0 }` (not an error)

## Test plan

- [x] `npx tsc --noEmit -p mcp/tsconfig.json` — typecheck passes
- [x] `npx vitest run tests/mcp-tools.test.ts` — 80 tests pass (72 existing + 8 new)
- [ ] Deploy MCP Worker → call `list_clusters` via JSON-RPC
- [ ] Verify response at resolution 1.0 and 2.0
- [ ] `npx vitest run tests/mcp-smoke.test.ts` — regression

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)