### PR TITLE
docs: list_clusters + clustering exploration findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ mcp/
     index.ts         # OAuthProvider setup, CaptureService entrypoint (capture + undoLatest), McpApiHandler, resolveExternalToken bypass
     pipeline.ts      # Single source of truth for capture logic — called by Service Binding RPC + capture_note tool
     oauth.ts         # Consent page HTML renderer + AuthHandler (GET/POST /authorize)
-    tools.ts         # Tool definitions + handlers (search_notes, get_note, list_recent, get_related, capture_note, remove_note)
+    tools.ts         # Tool definitions + handlers (search_notes, get_note, list_recent, get_related, capture_note, remove_note, list_clusters)
     auth.ts          # Bearer token auth (validateAuth, isStaticTokenRequest, timingSafeEqual — constant-time comparison)
     config.ts        # Config loading with secret validation
     db.ts            # DB read/write functions (fetchNote, listRecentNotes, searchNotes, insertNote, …)
@@ -370,11 +370,11 @@ Verify: `curl "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getWebhookInfo"
 - **Phase 2b (complete):** Gardening pipeline — nightly similarity linker. Originally included SKOS tag normalization and chunk generation, both removed in v4.0.0 (#128). Tagged `v2.5.0`.
 - **Phase 2c (complete):** OAuth 2.1 for MCP server. Authorization Code + PKCE via `@cloudflare/workers-oauth-provider`, DCR enabled, `resolveExternalToken` for static token bypass, consent page protected by `CONSENT_SECRET`. Verified with Claude.ai web connector. Cursor/ChatGPT verification deferred (#102). Tagged `v3.0.0`.
 - **v3.1.0 (complete):** Drop type/intent/modality from capture pipeline (#110). Clean-slate v3 schema. 10-field → 7-field → 6-field LLM contract (entities removed from capture in #113). Embedding format simplified to `[Tags: ...] text`. Corpus re-captured from raw_input.
-- **v4.0.0 (complete):** Schema simplification bundle (#128, PR #131). Dropped 3 tables (concepts, note_concepts, note_chunks), 3 columns (refined_tags, maturity, importance_score), 2 RPC functions (match_chunks, batch_update_refined_tags). Link types simplified from 9 → 3 (contradicts, related, is-similar-to). MCP tools reduced from 8 → 5. Gardener simplified to similarity linking only.
+- **v4.0.0 (complete):** Schema simplification bundle (#128, PR #131). Dropped 3 tables (concepts, note_concepts, note_chunks), 3 columns (refined_tags, maturity, importance_score), 2 RPC functions (match_chunks, batch_update_refined_tags). Link types simplified from 9 → 3 (contradicts, related, is-similar-to). MCP tools reduced from 8 → 5 (later 7 with remove_note and list_clusters). Gardener simplified to similarity linking only (later extended with clustering).
 - **remove_note (complete):** MCP tool for note removal with time-dependent behavior (#87, PR #140). Notes < 11 min: permanently deleted. Older: soft archive. All existing tools now filter `archived_at IS NULL`. Renamed from `archive_note` — the old name promised archival but could permanently delete.
 - **Telegram /undo (complete):** `/undo` command hard-deletes most recent Telegram capture within grace window (#142, PR #143). Source-scoped (Telegram only), grace-window-only (refuses after 11 min). Bot commands registered automatically by `deploy.sh`.
 - **Automated backup (complete):** GitHub Actions workflow for daily Supabase database backup (#159, PRs #163, #165, #167). Three-file dump (roles, schema, data) to configurable private GitHub repo. Data scoped to `--schema public`. Verification checks, optional Telegram failure alerts. Documented in `docs/setup.md` section 8 as a user-configurable feature.
-- **Cluster exploration (implementation in progress):** Louvain community detection via Graphology. PR 1 of 2 delivered (#156, PR #164): gardener computes multi-resolution clusters (cosine-only) and stores in `clusters` table. Verified against 186 notes — 9 clusters at res 1.0, coherent labels. PR 2 of 2 pending: `list_clusters` MCP tool reads pre-computed results. Tags, links, entities are upgrade paths (#151, #147, #125).
+- **Cluster exploration (complete):** Louvain community detection via Graphology. Gardener computes multi-resolution clusters (cosine-only) nightly, stores in `clusters` table (#156, PR #164). `list_clusters` MCP tool exposes them with resolution parameter and gravity ordering (#157, PR #172). Verified against 186 notes — 9 clusters at res 1.0, 12 at res 2.0, coherent labels. Tags, links, entities are upgrade paths (#151, #147, #125).
 - **Phase 3 (deferred):** Associative trails, location extraction.
 
 ## Deploy

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The MCP server is the primary interface, usable by any MCP-capable agent:
 | `get_note` | Fetch a single note — body, raw_input (source of truth), links, corrections. |
 | `list_recent` | Most recent notes, newest first. |
 | `get_related` | All linked notes in both directions with link types and confidence. |
+| `list_clusters` | See the shape of your thinking. Thematic clusters detected by the gardener — resolution controls zoom level. |
 | `capture_note` | Pass raw words — the server runs the full capture pipeline. Do not pre-structure. |
 | `remove_note` | Remove a note. Recent notes (< grace window) are permanently deleted; older notes are soft-archived and recoverable. |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,6 +111,7 @@ The MCP Worker implements JSON-RPC 2.0 over HTTP with dual authentication: OAuth
 | `get_related` | All linked notes in both directions, ordered capture-time first then gardener by confidence |
 | `capture_note` | Full capture pipeline (same logic as Telegram, synchronous) |
 | `remove_note` | Remove a note — permanent delete if recent (< grace window), soft archive if older |
+| `list_clusters` | Thematic clusters from the gardener. Resolution parameter (1.0/1.5/2.0) controls granularity. Gravity-ordered. |
 
 Tool descriptions in `TOOL_DEFINITIONS` (mcp/src/tools.ts) include behavioral guidance for connecting agents — what kind of input to pass, how to interpret results, when to use each tool. The `capture_note` description explicitly instructs agents to pass user's raw words without cleaning up or pre-structuring. These descriptions are the only guidance a connecting agent receives about how to use ContemPlace.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1170,3 +1170,19 @@ A supplementary mechanism difference: capture-time matching compares raw text ag
 **Why:** A 10-note random sample of `get_related` results showed 100% gardener/capture duplication, which would have led to a false conclusion that the gardener adds no new signal. Full overlap analysis revealed 13 genuinely new connections out of 117 (11.1% novelty rate) — all in the 0.65–0.70 band, invisible at the old 0.70 threshold. The new connections break down by failure mode: 9 from context-window truncation (dense topics where the top-5 candidate window was too narrow), 4 from backward blindness (earlier notes that couldn't evaluate later arrivals). Random sampling under-represents sparse signal — it naturally lands in dense clusters where capture was thorough.
 
 **Source:** #149 qualitative evaluation, 2026-03-18. The `scripts/threshold-analysis.ts` script covers distribution and sweep; the overlap analysis was done ad-hoc via direct DB queries and should be added to the script for future threshold reviews.
+
+## list_clusters: resolution passthrough, not validation (2026-03-18)
+
+**Decision:** The `list_clusters` MCP tool passes the resolution parameter through to the DB query as-is — no validation against available values, no clamping to [1.0, 1.5, 2.0]. If you ask for resolution 0.7, you get back an empty result.
+
+**Why:** The available resolutions are configured via `GARDENER_CLUSTER_RESOLUTIONS` and can change without redeploying the MCP Worker. Hardcoding validation in the tool would create a coupling between gardener config and MCP config. The tool description lists the defaults ("Available: 1.0, 1.5, 2.0") as guidance, and agents follow it. An empty result for a non-existent resolution is a clear enough signal.
+
+**Source:** #157 implementation. Kept simple to match the pattern of other tools that don't validate enum values.
+
+## Tag signal is the highest-value clustering upgrade (2026-03-18)
+
+**Decision:** Tag Jaccard similarity (#151/#147) is the next signal to add to the clustering edge weights, ahead of explicit links or entities.
+
+**Why:** Live exploration of the 186-note corpus revealed that semantically related notes with shared tags but different embedding contexts (e.g., "Lightroom backup" at 0.32 cosine vs. "device loss contingency" at 0.33 cosine vs. "ContemPlace backup" at 0.45 cosine — all sharing the `backup` tag) fall below the cosine floor and remain unclustered. Tag Jaccard would boost these edges above the clustering threshold. The #152 experiment showed only 5.4% of note pairs share any tag, so the signal is sparse but precisely targeted at the gap cosine-only misses. Links reinforce existing structure rather than bridging gaps; entities aren't populated yet (#125).
+
+**Source:** Live cluster exploration during #157 verification. Backup notes (Lightroom, device loss, ContemPlace) as concrete example.

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,7 +21,7 @@ npx vitest run tests/parser.test.ts tests/undo.test.ts \
 # Or individually:
 npx vitest run tests/parser.test.ts              # Capture response parsing
 npx vitest run tests/undo.test.ts                # /undo command (grace window, source filter)
-npx vitest run tests/mcp-tools.test.ts           # All 6 MCP tool handlers
+npx vitest run tests/mcp-tools.test.ts           # All 7 MCP tool handlers
 npx vitest run tests/mcp-dispatch.test.ts        # JSON-RPC dispatch
 npx vitest run tests/mcp-oauth.test.ts           # Consent page + AuthHandler
 npx vitest run tests/mcp-index.test.ts           # OAuthProvider + resolveExternalToken

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -175,7 +175,7 @@ The workflow includes verification checks (non-empty files, pgvector presence, R
 
 Documented in `docs/setup.md` section 8 as a user-configurable feature — any ContemPlace fork enables daily backup by adding three GitHub settings.
 
-## Cluster exploration — implementation in progress
+## Cluster exploration — complete (v1)
 
 The synthesis layer (#120) was designed as MOC generation from fragment clusters. A first-principles design session (2026-03-16) reframed the question: the real use case isn't narrative summarization — it's **undirected browsing**. Seeing the shape of your thinking without knowing what you're looking for. The Obsidian graph view served this; nothing in the current MCP surface does.
 
@@ -193,6 +193,14 @@ Delivered:
 - **Labels** — top-3 most frequent tags, no LLM calls (gardener stays LLM-free)
 
 Live results (186 notes): 9 clusters at res 1.0 (modularity 0.60), 11 at 1.5, 12 at 2.0. Coherent labels: pen-plotting/printmaking/generative-art, laser-cutting/instrument-design, audio-plugin/plugdata/sound-soup, note-taking/knowledge-capture, contemplace/mcp/knowledge-management.
+
+### list_clusters MCP tool — delivered (PR #172, 2026-03-18)
+
+PR 2 of 2: agents can now browse clusters via the `list_clusters` tool. Resolution parameter controls zoom level. Clusters ordered by gravity (recent active topics first). Note titles resolved at read time with archived notes filtered.
+
+Live exploration validated that multi-resolution zoom reveals genuine structure: the pen-plotting cluster splits into plotter-specific vs. correspondence/printmaking at resolution 1.5. The ContemPlace cluster splits into product thinking vs. infrastructure at 2.0. 15/186 notes remain unclustered — genuinely isolated fragments (garden furniture, Lightroom backup, weather observations) that don't connect to any thread yet.
+
+The exploration also surfaced that **tag signal is the highest-value next upgrade**: notes sharing the `backup` tag (Lightroom, device loss, ContemPlace backup) have cosine similarity 0.28–0.45 — below the clustering threshold but clearly related. Tag Jaccard would bridge them.
 
 ### Design decisions
 
@@ -212,12 +220,12 @@ A local experiment script (`scripts/cluster-experiment.ts`) ran weighted graph c
 - **Tags add marginal signal.** Only 5.4% of note pairs share any tag.
 - **Overlap is real.** 134/164 notes change cluster across resolutions. Modularity is low (0.27–0.32).
 
-### Next steps
+### Upgrade path
 1. ~~**#152** — Experiment~~ **Done.**
-2. ~~**#156** — Gardener clustering pipeline (PR 1 of 2)~~ **Done.** (PR #164)
-3. **PR 2 of 2** — `list_clusters` MCP tool (reads pre-computed clusters)
+2. ~~**#156** — Gardener clustering pipeline~~ **Done.** (PR #164)
+3. ~~**#157** — `list_clusters` MCP tool~~ **Done.** (PR #172)
 4. **#149** — Threshold assessment
-5. **#151** — Capture-time tag quality and consistency
+5. **#151** — Capture-time tag quality and consistency — **highest-value clustering upgrade** (bridges backup-type gaps)
 6. **#147** — Gardener-time tag normalization
 7. **#125** — Entity dictionary (fourth clustering signal)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -125,6 +125,18 @@ You don't see any of this happen. You don't interact with the gardener. The next
 
 This is the difference between a note store and a knowledge graph. The gardener turns your accumulation into something you can navigate.
 
+### Exploring clusters
+
+Ask any MCP-connected agent to show your clusters. The agent calls `list_clusters` and gets back a gravity-ordered map of your thinking — recent active topics first, older quiet threads toward the bottom.
+
+The resolution parameter is a zoom control. At 1.0, you see broad themes — making, thinking-about-thinking, tools. At 2.0, those themes split: making separates into plotter-specific work and correspondence/printmaking; your ContemPlace notes separate into product thinking and infrastructure.
+
+What makes this useful is what you *don't* see. You never organized anything. The clusters emerged from the embeddings — notes that talk about similar things end up near each other, and the Louvain algorithm finds the boundaries. Some of those boundaries are obvious (instruments vs. note-taking philosophy). Others surface threads you hadn't noticed running through your fragments.
+
+The unclustered notes matter too. A handful of fragments sitting outside every cluster tells you something — these are genuinely standalone thoughts. If you capture more on the same topic, a cluster will form. Until then, they wait.
+
+**What gravity tells you:** A cluster with high gravity is where your recent attention is. A cluster with low gravity is an old thread — still coherent, still there, just not where you've been lately. This isn't a quality judgment. It's a recency signal. Old clusters with dormant gravity are often the most interesting to revisit.
+
 ---
 
 ## Backups: what protects your data


### PR DESCRIPTION
## Summary

Post-merge documentation sweep for `list_clusters` MCP tool (PR #172) plus findings from live cluster exploration.

- `list_clusters` added to MCP tools tables in README and architecture.md
- New "Exploring clusters" section in usage.md — how resolution zoom works, what gravity tells you, what unclustered notes mean
- 2 new ADRs: resolution passthrough (no validation), tag signal as highest-value clustering upgrade
- Roadmap: clustering marked complete (v1), upgrade path updated
- CLAUDE.md: tools list and phase scope updated

## Test plan

- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)