### PR TITLE
fix: limit list_clusters context size with notes_per_cluster

### DIFF
--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -95,13 +95,17 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'list_clusters',
-    description: 'List thematic clusters detected by the gardener. Clusters group notes by semantic similarity — call with no parameters to see the landscape of accumulated thinking. Use resolution to control granularity: 1.0 (broad themes), 1.5 (finer distinctions), 2.0 (narrow topics).',
+    description: 'List thematic clusters detected by the gardener. Clusters group notes by semantic similarity — call with no parameters to see the landscape of accumulated thinking. Use resolution to control granularity: 1.0 (broad themes), 1.5 (finer distinctions), 2.0 (narrow topics). Each cluster includes a sample of note titles (default 5) — use search_notes with tag filters or get_note to explore further.',
     inputSchema: {
       type: 'object',
       properties: {
         resolution: {
           type: 'number',
-          description: 'Cluster resolution (default 1.0). Available: 1.0, 1.5, 2.0. Lower = fewer larger clusters.',
+          description: 'Cluster resolution (default 1.0). Lower = fewer larger clusters.',
+        },
+        notes_per_cluster: {
+          type: 'number',
+          description: 'Max note titles to include per cluster (default 5, max 50, 0 = none). Full count is always in note_count.',
         },
       },
       required: [],
@@ -268,6 +272,7 @@ export async function handleListClusters(
   db: SupabaseClient,
 ): Promise<object> {
   const resolution = typeof args['resolution'] === 'number' ? args['resolution'] : 1.0;
+  const notesPerCluster = clamp(args['notes_per_cluster'] as number | undefined, 0, 50, 5);
 
   try {
     const { clusters, computed_at } = await fetchClusters(db, resolution);
@@ -280,7 +285,7 @@ export async function handleListClusters(
         top_tags: c.top_tags,
         note_count: c.note_count,
         gravity: c.gravity,
-        notes: c.notes,
+        notes: c.notes.slice(0, notesPerCluster),
       })),
       resolution,
       cluster_count: clusters.length,

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -853,6 +853,59 @@ describe('handleListClusters', () => {
     });
   });
 
+  describe('notes_per_cluster', () => {
+    const bigCluster = {
+      ...MOCK_CLUSTER,
+      note_count: 10,
+      notes: Array.from({ length: 10 }, (_, i) => ({
+        id: `aaaaaaaa-0000-0000-0000-00000000${String(i).padStart(4, '0')}`,
+        title: `Note ${i}`,
+      })),
+    };
+
+    it('defaults to 5 notes per cluster', async () => {
+      vi.mocked(fetchClusters).mockResolvedValueOnce({
+        clusters: [bigCluster],
+        computed_at: '2026-03-18T02:00:00.000Z',
+      });
+      const r = toolResult(await handleListClusters({}, mockDb));
+      const body = JSON.parse(r.content[0]!.text);
+      expect(body.clusters[0].notes).toHaveLength(5);
+      expect(body.clusters[0].note_count).toBe(10);
+    });
+
+    it('respects explicit notes_per_cluster value', async () => {
+      vi.mocked(fetchClusters).mockResolvedValueOnce({
+        clusters: [bigCluster],
+        computed_at: '2026-03-18T02:00:00.000Z',
+      });
+      const r = toolResult(await handleListClusters({ notes_per_cluster: 2 }, mockDb));
+      const body = JSON.parse(r.content[0]!.text);
+      expect(body.clusters[0].notes).toHaveLength(2);
+    });
+
+    it('returns no notes when notes_per_cluster is 0', async () => {
+      vi.mocked(fetchClusters).mockResolvedValueOnce({
+        clusters: [bigCluster],
+        computed_at: '2026-03-18T02:00:00.000Z',
+      });
+      const r = toolResult(await handleListClusters({ notes_per_cluster: 0 }, mockDb));
+      const body = JSON.parse(r.content[0]!.text);
+      expect(body.clusters[0].notes).toHaveLength(0);
+      expect(body.clusters[0].note_count).toBe(10);
+    });
+
+    it('clamps notes_per_cluster to max 50', async () => {
+      vi.mocked(fetchClusters).mockResolvedValueOnce({
+        clusters: [bigCluster],
+        computed_at: '2026-03-18T02:00:00.000Z',
+      });
+      const r = toolResult(await handleListClusters({ notes_per_cluster: 100 }, mockDb));
+      const body = JSON.parse(r.content[0]!.text);
+      expect(body.clusters[0].notes).toHaveLength(10);
+    });
+  });
+
   describe('error handling', () => {
     it('returns toolError when fetchClusters throws', async () => {
       vi.mocked(fetchClusters).mockRejectedValueOnce(new Error('DB error'));


### PR DESCRIPTION
## Summary

- Add `notes_per_cluster` parameter to `list_clusters` (default 5, max 50, 0 = none)
- Agents get a sample of note titles per cluster instead of all 171 — `note_count` always shows the full size
- Surfaced during #176 UX validation: the full res 1.0 response was consuming excessive agent context

## Test plan

- [x] Typecheck clean (`npx tsc --noEmit -p mcp/tsconfig.json`)
- [x] 84 MCP tool tests pass (4 new: default slicing, explicit value, zero, clamp to max)
- [x] Existing tests unaffected (mock cluster has 3 notes < default 5)
- [ ] Deploy and verify via curl: default call returns ≤5 notes per cluster, `notes_per_cluster: 0` returns none

Refs #176. Also created #179 for `available_resolutions` in response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)