### PR TITLE
feat: list_clusters returns available_resolutions

### DIFF
--- a/mcp/src/db.ts
+++ b/mcp/src/db.ts
@@ -279,6 +279,15 @@ export interface ClusterWithNotes {
   notes: ClusterNote[];
 }
 
+// Return distinct resolution values present in the clusters table.
+export async function fetchAvailableResolutions(db: SupabaseClient): Promise<number[]> {
+  const { data } = await db
+    .from('clusters')
+    .select('resolution')
+    .order('resolution', { ascending: true });
+  return [...new Set((data ?? []).map((r: { resolution: number }) => r.resolution))];
+}
+
 // Fetch clusters at a given resolution, with note titles resolved.
 // Archived notes are silently filtered out at read time.
 export async function fetchClusters(

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -2,7 +2,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import type OpenAI from 'openai';
 import type { Config } from './config';
 import { embedText } from './embed';
-import { fetchNote, fetchNoteLinks, listRecentNotes, searchNotes, fetchNoteForArchive, archiveNote, hardDeleteNote, fetchClusters } from './db';
+import { fetchNote, fetchNoteLinks, listRecentNotes, searchNotes, fetchNoteForArchive, archiveNote, hardDeleteNote, fetchClusters, fetchAvailableResolutions } from './db';
 import { runCapturePipeline } from './pipeline';
 
 // ── Validation helpers ────────────────────────────────────────────────────────
@@ -95,13 +95,13 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'list_clusters',
-    description: 'List thematic clusters detected by the gardener. Clusters group notes by semantic similarity — call with no parameters to see the landscape of accumulated thinking. Use resolution to control granularity: 1.0 (broad themes), 1.5 (finer distinctions), 2.0 (narrow topics). Each cluster includes a sample of note titles (default 5) — use search_notes with tag filters or get_note to explore further.',
+    description: 'List thematic clusters detected by the gardener. Clusters group notes by semantic similarity — call with no parameters to see the landscape of accumulated thinking. The response includes available_resolutions so you know which values to request. Each cluster includes a sample of note titles (default 5) — use search_notes with tag filters or get_note to explore further.',
     inputSchema: {
       type: 'object',
       properties: {
         resolution: {
           type: 'number',
-          description: 'Cluster resolution (default 1.0). Lower = fewer larger clusters.',
+          description: 'Cluster resolution (default 1.0). Lower = fewer larger clusters. Check available_resolutions in the response for valid values.',
         },
         notes_per_cluster: {
           type: 'number',
@@ -275,7 +275,10 @@ export async function handleListClusters(
   const notesPerCluster = clamp(args['notes_per_cluster'] as number | undefined, 0, 50, 5);
 
   try {
-    const { clusters, computed_at } = await fetchClusters(db, resolution);
+    const [{ clusters, computed_at }, availableResolutions] = await Promise.all([
+      fetchClusters(db, resolution),
+      fetchAvailableResolutions(db),
+    ]);
 
     const clusteredNotes = clusters.reduce((sum, c) => sum + c.note_count, 0);
 
@@ -288,6 +291,7 @@ export async function handleListClusters(
         notes: c.notes.slice(0, notesPerCluster),
       })),
       resolution,
+      available_resolutions: availableResolutions,
       cluster_count: clusters.length,
       clustered_notes: clusteredNotes,
       computed_at,

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -23,6 +23,7 @@ vi.mock('../mcp/src/db', () => ({
   archiveNote: vi.fn().mockResolvedValue(undefined),
   hardDeleteNote: vi.fn().mockResolvedValue(undefined),
   fetchClusters: vi.fn().mockResolvedValue({ clusters: [], computed_at: null }),
+  fetchAvailableResolutions: vi.fn().mockResolvedValue([1.0, 1.5, 2.0]),
 }));
 
 vi.mock('../mcp/src/embed', () => ({
@@ -67,6 +68,7 @@ import {
   archiveNote,
   hardDeleteNote,
   fetchClusters,
+  fetchAvailableResolutions,
 } from '../mcp/src/db';
 import { embedText } from '../mcp/src/embed';
 import { runCaptureAgent } from '../mcp/src/capture';
@@ -822,6 +824,15 @@ describe('handleListClusters', () => {
       expect(body.resolution).toBe(1.0);
       expect(body.clustered_notes).toBe(3);
       expect(body.computed_at).toBe('2026-03-18T02:00:00.000Z');
+      expect(body.available_resolutions).toEqual([1.0, 1.5, 2.0]);
+    });
+
+    it('returns available_resolutions from DB', async () => {
+      vi.mocked(fetchClusters).mockResolvedValueOnce({ clusters: [], computed_at: null });
+      vi.mocked(fetchAvailableResolutions).mockResolvedValueOnce([1.0, 2.0]);
+      const r = toolResult(await handleListClusters({}, mockDb));
+      const body = JSON.parse(r.content[0]!.text);
+      expect(body.available_resolutions).toEqual([1.0, 2.0]);
     });
 
     it('returns cluster fields correctly', async () => {


### PR DESCRIPTION
## Summary

- Add `fetchAvailableResolutions()` to `mcp/src/db.ts` — queries distinct resolutions from clusters table
- `list_clusters` response now includes `available_resolutions` array
- Tool description updated to reference the field instead of hardcoding "1.0, 1.5, 2.0"

Closes #179

## Test plan

- [x] Typecheck clean
- [x] 85 MCP tool tests pass (1 new: available_resolutions from DB)
- [ ] Deploy and verify via curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)