### PR TITLE
fix: revert supabase/setup-cli to @v1 — v2 never published

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Install Supabase CLI
-        uses: supabase/setup-cli@v2
+        uses: supabase/setup-cli@v1
         with:
           version: latest
 


### PR DESCRIPTION
## Summary
- Reverts `supabase/setup-cli@v2` → `@v1` in the backup workflow
- v2 was never published by Supabase — latest release is v1.6.0 (node20 runtime), compatible with `ubuntu-latest` runners
- Fixes the daily backup failure introduced by adfc619

## Test plan
- [ ] Workflow dispatch triggers successfully after merge
- [ ] `supabase db dump` runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)