### PR TITLE
docs: clustering session insights — workflow, interaction paradigm, tool description

### DIFF
--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -55,6 +55,8 @@ Fragments cluster around themes over time. The gardener detects these clusters b
 
 This is how ideas evolve in the system. Not by revising old notes, but by accumulating new fragments that cluster, link, and eventually coalesce into themes you can browse. The primary use case is undirected exploration — seeing what's on your mind, tracing how ideas connect across domains, discovering that instrument-making and laser-cutting share a thread you hadn't noticed. Whether narrative MOC-like synthesis is needed on top of this is an open question (#120) that depends on whether cluster exploration alone satisfies the browsing use case.
 
+The interaction paradigm is three-way: the tool returns navigable structure, the agent synthesizes insight from that structure using domain reasoning and user context, and the human confirms, extends, or redirects. Clustering doesn't return insights — it returns a map that an agent can read. The agent adds the meaning. This applies to all retrieval tools, but clustering makes it most visible because the agent's synthesis layer (noticing what split, what held, what's absent) is where the value actually lives.
+
 *Source: #116 (2026-03-14), reframed in #144 design session (2026-03-17). Literature basis: Milo's MOCs (navigational superstructure), Ahrens (look into the slip-box to see where ideas cluster). Algorithm choice informed by literature review (#148).*
 
 ### 5. Maturity is computed, not assigned

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -137,6 +137,22 @@ The unclustered notes matter too. A handful of fragments sitting outside every c
 
 **What gravity tells you:** A cluster with high gravity is where your recent attention is. A cluster with low gravity is an old thread — still coherent, still there, just not where you've been lately. This isn't a quality judgment. It's a recency signal. Old clusters with dormant gravity are often the most interesting to revisit.
 
+### The clustering workflow
+
+A clustering session follows a natural funnel — each step narrows focus based on what the previous step revealed.
+
+1. **Landscape.** Call `list_clusters` with no parameters. The agent reads the gravity-ordered map and can say "here are the themes your brain has been working on" before reading a single note body. This is the cold-start entry point for any reflection session.
+
+2. **Resolution comparison.** Call `list_clusters` again at a different resolution (e.g., 1.5). The agent narrates what split, what held, and what newly surfaced. This is a high-value single move — low effort, often the most structurally informative step. A cluster that splits reveals internal conceptual diversity; one that holds at higher resolution is genuinely coherent.
+
+3. **Title scan.** For an interesting cluster, increase `notes_per_cluster` to see all its titles. The agent reads titles for philosophical anchors, conceptual junctions, and surprising members.
+
+4. **Graph walk.** From a well-connected or philosophically anchored note, call `get_related` to explore the link topology. `get_related` is a second-stage tool — most useful once you've identified a specific note to anchor from, not as a starting point.
+
+5. **Boundary search.** For any cluster, the agent can ask "what would this cluster contain if the orientation were different?" and search for those terms at low threshold. Finding nothing is informative — it reveals the framing and assumptions behind the cluster. The absence of expected concepts often says more about the user's orientation than the presence of captured ones.
+
+Not every session goes through all five steps. Landscape orientation alone is often enough for a check-in. The funnel is there when you want to go deeper.
+
 ---
 
 ## Backups: what protects your data

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -95,7 +95,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'list_clusters',
-    description: 'List thematic clusters detected by the gardener. Clusters group notes by semantic similarity — call with no parameters to see the landscape of accumulated thinking. The response includes available_resolutions so you know which values to request. Each cluster includes a sample of note titles (default 5) — use search_notes with tag filters or get_note to explore further.',
+    description: 'List thematic clusters detected by the gardener. Clusters group notes by semantic similarity — call with no parameters to see the landscape of accumulated thinking. Results are ordered by gravity (size × recency) — high-gravity clusters are where recent attention is concentrated. Try comparing resolutions (e.g., default 1.0 then 1.5) to see which clusters split, revealing internal conceptual structure. The response includes available_resolutions so you know which values to request. Each cluster includes a sample of note titles (default 5) — use search_notes with tag filters or get_note to explore further.',
     inputSchema: {
       type: 'object',
       properties: {


### PR DESCRIPTION
## Summary

- Document the canonical 5-step clustering workflow (landscape → resolution comparison → title scan → graph walk → boundary search) in `docs/usage.md`
- Add the three-way interaction paradigm to `docs/philosophy.md` — tools return navigable structure, agents synthesize insight, humans redirect
- Improve `list_clusters` tool description: explain gravity ordering, encourage multi-resolution comparison

## Context

First real-world clustering session on a live corpus. The session validated the feature and revealed usage patterns worth documenting. Four design issues created from the session findings:

- #184 — Hub notes in cluster response
- #185 — Multi-resolution compare mode
- #186 — Internal cluster structure beyond top-3 labels
- #188 — Absence detection for clusters

Refs #184, #185, #186, #188

## Test plan

- [ ] `npx tsc --noEmit` passes (tools.ts description change is string-only)
- [ ] Docs read correctly in rendered markdown
- [ ] No note content or private data in any public-facing text

🤖 Generated with [Claude Code](https://claude.com/claude-code)