### PR TITLE
feat: surface hub notes in list_clusters response

### DIFF
--- a/mcp/src/db.ts
+++ b/mcp/src/db.ts
@@ -1,6 +1,6 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import type { Config } from './config';
-import type { CaptureLink, CaptureResult, MatchedNote, NoteRow, RecentFragment, LinkWithTitle, ClusterRow, ClusterNote } from './types';
+import type { CaptureLink, CaptureResult, MatchedNote, NoteRow, RecentFragment, LinkWithTitle, ClusterRow, ClusterNote, HubNote } from './types';
 
 export type SupabaseClientType = SupabaseClient;
 
@@ -308,6 +308,7 @@ export interface ClusterWithNotes {
   note_count: number;
   gravity: number;
   notes: ClusterNote[];
+  hub_notes: HubNote[];
 }
 
 // Return distinct resolution values present in the clusters table.
@@ -343,12 +344,16 @@ export async function fetchClusters(
   // Collect all note IDs across all clusters
   const allNoteIds = [...new Set(rows.flatMap(r => r.note_ids))];
 
-  // Batch-fetch titles (respecting archived_at IS NULL)
-  const { data: noteRows } = await db
-    .from('notes')
-    .select('id, title')
-    .in('id', allNoteIds)
-    .is('archived_at', null);
+  // Batch-fetch titles and links in parallel
+  const [{ data: noteRows }, { data: linkRows }] = await Promise.all([
+    db.from('notes')
+      .select('id, title')
+      .in('id', allNoteIds)
+      .is('archived_at', null),
+    db.from('links')
+      .select('from_id, to_id')
+      .or(`from_id.in.(${allNoteIds.join(',')}),to_id.in.(${allNoteIds.join(',')})`),
+  ]);
 
   const titleMap = new Map<string, string>();
   if (noteRows) {
@@ -357,11 +362,37 @@ export async function fetchClusters(
     }
   }
 
-  // Map titles back to clusters, filter out archived notes
+  // Keep raw link pairs for per-cluster hub note computation
+  const activeLinkPairs: Array<{ from_id: string; to_id: string }> = [];
+  const activeIds = new Set(titleMap.keys());
+  if (linkRows) {
+    for (const link of linkRows as Array<{ from_id: string; to_id: string }>) {
+      if (activeIds.has(link.from_id) && activeIds.has(link.to_id)) {
+        activeLinkPairs.push(link);
+      }
+    }
+  }
+
+  // Map titles back to clusters, filter out archived notes, compute hub notes
   const clusters: ClusterWithNotes[] = rows.map(row => {
     const activeNotes: ClusterNote[] = row.note_ids
       .filter(id => titleMap.has(id))
       .map(id => ({ id, title: titleMap.get(id)! }));
+
+    // Hub notes: top 2 by intra-cluster link count
+    const clusterIds = new Set(activeNotes.map(n => n.id));
+    const clusterLinkCounts = new Map<string, number>();
+    for (const link of activeLinkPairs) {
+      if (clusterIds.has(link.from_id) && clusterIds.has(link.to_id)) {
+        clusterLinkCounts.set(link.from_id, (clusterLinkCounts.get(link.from_id) ?? 0) + 1);
+        clusterLinkCounts.set(link.to_id, (clusterLinkCounts.get(link.to_id) ?? 0) + 1);
+      }
+    }
+    const hubNotes: HubNote[] = activeNotes
+      .map(n => ({ id: n.id, title: n.title, link_count: clusterLinkCounts.get(n.id) ?? 0 }))
+      .filter(n => n.link_count > 0)
+      .sort((a, b) => b.link_count - a.link_count)
+      .slice(0, 2);
 
     return {
       label: row.label,
@@ -369,6 +400,7 @@ export async function fetchClusters(
       note_count: activeNotes.length,
       gravity: row.gravity,
       notes: activeNotes,
+      hub_notes: hubNotes,
     };
   });
 

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -95,7 +95,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'list_clusters',
-    description: 'List thematic clusters detected by the gardener. Clusters group notes by semantic similarity — call with no parameters to see the landscape of accumulated thinking. Results are ordered by gravity (size × recency) — high-gravity clusters are where recent attention is concentrated. Try comparing resolutions (e.g., default 1.0 then 1.5) to see which clusters split, revealing internal conceptual structure. The response includes available_resolutions so you know which values to request. Each cluster includes a sample of note titles (default 5) — use search_notes with tag filters or get_note to explore further.',
+    description: 'List thematic clusters detected by the gardener. Clusters group notes by semantic similarity — call with no parameters to see the landscape of accumulated thinking. Results are ordered by gravity (size × recency) — high-gravity clusters are where recent attention is concentrated. Try comparing resolutions (e.g., default 1.0 then 1.5) to see which clusters split, revealing internal conceptual structure. The response includes available_resolutions so you know which values to request. Each cluster includes a sample of note titles (default 5) and hub_notes — the 1–2 notes with the most intra-cluster links, which act as conceptual anchors. Start depth dives with get_related on a hub note.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -289,6 +289,7 @@ export async function handleListClusters(
         note_count: c.note_count,
         gravity: c.gravity,
         notes: c.notes.slice(0, notesPerCluster),
+        hub_notes: c.hub_notes,
       })),
       resolution,
       available_resolutions: availableResolutions,

--- a/mcp/src/types.ts
+++ b/mcp/src/types.ts
@@ -101,6 +101,12 @@ export interface ClusterNote {
   title: string;
 }
 
+export interface HubNote {
+  id: string;
+  title: string;
+  link_count: number;
+}
+
 export interface ClusterRow {
   label: string;
   top_tags: string[];

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -815,6 +815,9 @@ const MOCK_CLUSTER = {
     { id: 'aaaaaaaa-0000-0000-0000-000000000002', title: 'Italian cooking philosophy' },
     { id: 'aaaaaaaa-0000-0000-0000-000000000003', title: 'Pasta shapes and sauces' },
   ],
+  hub_notes: [
+    { id: 'aaaaaaaa-0000-0000-0000-000000000001', title: 'Homemade pasta basics', link_count: 4 },
+  ],
 };
 
 describe('handleListClusters', () => {
@@ -889,8 +892,32 @@ describe('handleListClusters', () => {
       expect(cluster.notes[0].title).toBe('Homemade pasta basics');
     });
 
+    it('includes hub_notes in cluster response', async () => {
+      vi.mocked(fetchClusters).mockResolvedValueOnce({
+        clusters: [MOCK_CLUSTER],
+        computed_at: '2026-03-18T02:00:00.000Z',
+      });
+      const r = toolResult(await handleListClusters({}, mockDb));
+      const body = JSON.parse(r.content[0]!.text);
+      const cluster = body.clusters[0];
+      expect(cluster.hub_notes).toHaveLength(1);
+      expect(cluster.hub_notes[0].title).toBe('Homemade pasta basics');
+      expect(cluster.hub_notes[0].link_count).toBe(4);
+    });
+
+    it('returns empty hub_notes when no notes have links', async () => {
+      const noHubCluster = { ...MOCK_CLUSTER, hub_notes: [] };
+      vi.mocked(fetchClusters).mockResolvedValueOnce({
+        clusters: [noHubCluster],
+        computed_at: '2026-03-18T02:00:00.000Z',
+      });
+      const r = toolResult(await handleListClusters({}, mockDb));
+      const body = JSON.parse(r.content[0]!.text);
+      expect(body.clusters[0].hub_notes).toEqual([]);
+    });
+
     it('sums clustered_notes across multiple clusters', async () => {
-      const cluster2 = { ...MOCK_CLUSTER, label: 'music / jazz', note_count: 5, notes: Array(5).fill(MOCK_CLUSTER.notes[0]) };
+      const cluster2 = { ...MOCK_CLUSTER, label: 'music / jazz', note_count: 5, notes: Array(5).fill(MOCK_CLUSTER.notes[0]), hub_notes: [] };
       vi.mocked(fetchClusters).mockResolvedValueOnce({
         clusters: [MOCK_CLUSTER, cluster2],
         computed_at: '2026-03-18T02:00:00.000Z',
@@ -910,6 +937,7 @@ describe('handleListClusters', () => {
         id: `aaaaaaaa-0000-0000-0000-00000000${String(i).padStart(4, '0')}`,
         title: `Note ${i}`,
       })),
+      hub_notes: [{ id: 'aaaaaaaa-0000-0000-0000-000000000000', title: 'Note 0', link_count: 3 }],
     };
 
     it('defaults to 5 notes per cluster', async () => {


### PR DESCRIPTION
## Summary
- Adds `hub_notes` field to each cluster in `list_clusters` — the top 1–2 notes with the most intra-cluster links
- Hub notes act as conceptual anchors — agents can jump straight to `get_related` on them instead of scanning all titles
- Link counting is per-cluster (only counts links where both endpoints are in the same cluster), computed at read time with a single batch query

## Changes
- **`mcp/src/types.ts`** — new `HubNote` interface
- **`mcp/src/db.ts`** — `fetchClusters` batch-fetches links in parallel with titles, computes per-cluster hub notes
- **`mcp/src/tools.ts`** — passes `hub_notes` through, updated tool description
- **`tests/mcp-tools.test.ts`** — hub_notes tests added, mocks updated

## Test plan
- [x] `npx tsc --noEmit -p mcp/tsconfig.json` — passes
- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run tests/mcp-tools.test.ts` — 90/90 pass
- [x] Full MCP unit suite — 210/210 pass (7 files)
- [x] MCP smoke tests — 26/26 pass
- [x] Deploy MCP Worker — deployed
- [x] `list_clusters` on live corpus — hub_notes appear for all 10 clusters
- [x] Verified: instrument-design cluster hub ("Lapsteel guitar with embedded DSP", 19 links) matches the conceptual junction discovered manually in first clustering session

Refs #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)